### PR TITLE
TatapWindow: Coding style and separate files per widget

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ executable(
     'src/Utils/TatapMathUtils.vala',
     'src/Utils/TatapStringUtils.vala',
     'src/Widgets/NavigationBox.vala',
+    'src/Widgets/ToolBarRevealer.vala',
     'src/Application.vala',
     'src/TatapFileList.vala',
     'src/TatapImage.vala',

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ executable(
     'src/Utils/TatapStringUtils.vala',
     'src/Widgets/NavigationBox.vala',
     'src/Widgets/ToolBarRevealer.vala',
+    'src/Widgets/ToolButton.vala',
     'src/Application.vala',
     'src/TatapFileList.vala',
     'src/TatapImage.vala',

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ executable(
     'src/Utils/TatapFileUtils.vala',
     'src/Utils/TatapMathUtils.vala',
     'src/Utils/TatapStringUtils.vala',
+    'src/Widgets/NavigationBox.vala',
     'src/Application.vala',
     'src/TatapFileList.vala',
     'src/TatapImage.vala',

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -3,6 +3,7 @@ src/Utils/TatapFileType.vala
 src/Utils/TatapFileUtils.vala
 src/Utils/TatapMathUtils.vala
 src/Utils/TatapStringUtils.vala
+src/Widgets/NavigationBox.vala
 src/Application.vala
 src/TatapFileList.vala
 src/TatapImage.vala

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -5,6 +5,7 @@ src/Utils/TatapMathUtils.vala
 src/Utils/TatapStringUtils.vala
 src/Widgets/NavigationBox.vala
 src/Widgets/ToolBarRevealer.vala
+src/Widgets/ToolButton.vala
 src/Application.vala
 src/TatapFileList.vala
 src/TatapImage.vala

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -4,6 +4,7 @@ src/Utils/TatapFileUtils.vala
 src/Utils/TatapMathUtils.vala
 src/Utils/TatapStringUtils.vala
 src/Widgets/NavigationBox.vala
+src/Widgets/ToolBarRevealer.vala
 src/Application.vala
 src/TatapFileList.vala
 src/TatapImage.vala

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -75,286 +75,255 @@ public class TatapWindow : Gtk.Window {
     private double y;
 
     public TatapWindow() {
-        headerbar = new HeaderBar();
-        {
-            ButtonBox button_box2 = new ButtonBox(Orientation.HORIZONTAL);
-            {
-                image_prev_button = new Button.from_icon_name("go-previous-symbolic", ICON_SIZE);
-                {
-                    image_prev_button.valign = Align.CENTER;
-                    image_prev_button.tooltip_text = _("Previous");
-                    image_prev_button.get_style_context().add_class("image_button");
-                    image_prev_button.clicked.connect(() => {
-                            if (file_list != null) {
-                                File? prev_file = file_list.get_prev_file(image.fileref);
-                                if (prev_file != null) {
-                                    open_file(prev_file.get_path());
-                                }
-                            }
-                        });
-                }
+        image_prev_button = new Button.from_icon_name("go-previous-symbolic", ICON_SIZE) {
+            valign = Align.CENTER,
+            tooltip_text = _("Previous")
+        };
+        image_prev_button.get_style_context().add_class("image_button");
+        image_prev_button.clicked.connect(() => {
+            if (file_list != null) {
+                File? prev_file = file_list.get_prev_file(image.fileref);
 
-                image_next_button = new Button.from_icon_name("go-next-symbolic", ICON_SIZE);
-                {
-                    image_next_button.valign = Align.CENTER;
-                    image_next_button.tooltip_text = _("Next");
-                    image_next_button.get_style_context().add_class("image_button");
-                    image_next_button.clicked.connect(() => {
-                            if (file_list != null) {
-                                File? next_file = file_list.get_next_file(image.fileref);
-                                debug("next file: %s", next_file.get_basename());
-                                if (next_file != null) {
-                                    open_file(next_file.get_path());
-                                }
-                            }
-                        });
+                if (prev_file != null) {
+                    open_file(prev_file.get_path());
                 }
-
-                button_box2.add(image_prev_button);
-                button_box2.add(image_next_button);
-                button_box2.set_layout(ButtonBoxStyle.EXPAND);
             }
+        });
 
-            ButtonBox header_button_box_right = new ButtonBox(Orientation.HORIZONTAL);
-            {
-                ToggleButton toolbar_toggle_button = new ToggleButton();
-                {
-                    Image toggle_toolbar_icon = new Image.from_icon_name("view-more-symbolic", ICON_SIZE);
+        image_next_button = new Button.from_icon_name("go-next-symbolic", ICON_SIZE) {
+            valign = Align.CENTER,
+            tooltip_text = _("Next")
+        };
+        image_next_button.get_style_context().add_class("image_button");
+        image_next_button.clicked.connect(() => {
+            if (file_list != null) {
+                File? next_file = file_list.get_next_file(image.fileref);
+                debug("next file: %s", next_file.get_basename());
 
-                    toolbar_toggle_button.tooltip_text = _("Menu");
-                    toolbar_toggle_button.add(toggle_toolbar_icon);
-                    toolbar_toggle_button.toggled.connect(() => {
-                            toolbar_revealer.reveal_child = toolbar_toggle_button.active;
-                        });
+                if (next_file != null) {
+                    open_file(next_file.get_path());
                 }
-
-                header_button_box_right.add(toolbar_toggle_button);
-                header_button_box_right.set_layout(ButtonBoxStyle.EXPAND);
             }
-            
-            headerbar.pack_start(button_box2);
-            headerbar.pack_end(header_button_box_right);
-            headerbar.show_close_button = true;
-        }
+        });
 
-        Overlay window_overlay = new Overlay();
-        {
-            image_container = new ScrolledWindow(null, null);
-            {
-                image = new TatapImage(true);
-                {
-                    image.get_style_context().add_class("image-view");
-                }
+        var button_box2 = new ButtonBox(Orientation.HORIZONTAL);
+        button_box2.add(image_prev_button);
+        button_box2.add(image_next_button);
+        button_box2.set_layout(ButtonBoxStyle.EXPAND);
 
-                image_container.add(image);
-                image_container.scroll_child.connect((a, b) => {
-                        print("Scroll Event\n");
-                        return false;
-                    });
-            }
+        var toggle_toolbar_icon = new Image.from_icon_name("view-more-symbolic", ICON_SIZE);
+        var toolbar_toggle_button = new ToggleButton() {
+            tooltip_text = _("Menu")
+        };
+        toolbar_toggle_button.add(toggle_toolbar_icon);
+        toolbar_toggle_button.toggled.connect(() => {
+            toolbar_revealer.reveal_child = toolbar_toggle_button.active;
+        });
 
-            Box revealer_box = new Box(Orientation.VERTICAL, 0);
-            {
-                toolbar_revealer = new Revealer();
-                {
-                    Box toolbar_hbox = new Box(Orientation.HORIZONTAL, 0);
-                    {
-                        ButtonBox button_box1 = new ButtonBox(Orientation.HORIZONTAL);
-                        {
-                            open_button = new Button();
-                            {
-                                Image open_button_icon = new Image.from_icon_name("document-open-symbolic",
-                                                                                ICON_SIZE);
+        var header_button_box_right = new ButtonBox(Orientation.HORIZONTAL);
+        header_button_box_right.add(toolbar_toggle_button);
+        header_button_box_right.set_layout(ButtonBoxStyle.EXPAND);
 
-                                open_button.tooltip_text = _("Open");
-                                open_button.add(open_button_icon);
-                                open_button.clicked.connect(() => {
-                                        on_open_button_clicked();
-                                    });
-                            }
+        headerbar = new HeaderBar() {
+            show_close_button = true
+        };
+        headerbar.pack_start(button_box2);
+        headerbar.pack_end(header_button_box_right);
 
-                            save_button = new Button.from_icon_name("document-save-symbolic", ICON_SIZE);
-                            {
-                                save_button.tooltip_text = _("Save as…");
-                                save_button.clicked.connect(() => {
-                                        on_save_button_clicked();
-                                    });
-                            }
+        image = new TatapImage(true);
+        image.get_style_context().add_class("image-view");
 
-                            button_box1.add(open_button);
-                            button_box1.add(save_button);
-                            button_box1.set_layout(ButtonBoxStyle.EXPAND);
-                            button_box1.margin = 5;
-                        }
-            
-                        ButtonBox button_box3 = new ButtonBox(Orientation.HORIZONTAL);
-                        {
-                            zoom_in_button = new Button.from_icon_name("zoom-in-symbolic", ICON_SIZE);
-                            {
-                                zoom_in_button.tooltip_text = _("Zoom in");
-                                zoom_in_button.get_style_context().add_class("image_overlay_button");
-                                zoom_in_button.clicked.connect(() => {
-                                        image.zoom_in();
-                                        set_title_label();
-                                        zoom_fit_button.sensitive = true;
-                                    });
-                            }
-            
-                            zoom_out_button = new Button.from_icon_name("zoom-out-symbolic", ICON_SIZE);
-                            {
-                                zoom_out_button.tooltip_text = _("Zoom out");
-                                zoom_out_button.get_style_context().add_class("image_overlay_button");
-                                zoom_out_button.clicked.connect(() => {
-                                        image.zoom_out();
-                                        set_title_label();
-                                        zoom_fit_button.sensitive = true;
-                                    });
-                            }
-            
-                            zoom_fit_button = new Button.from_icon_name("zoom-fit-best-symbolic", ICON_SIZE);
-                            {
-                                zoom_fit_button.tooltip_text = _("Fit to the page");
-                                zoom_fit_button.get_style_context().add_class("image_overlay_button");
-                                zoom_fit_button.clicked.connect(() => {
-                                        image.fit_image_to_window();
-                                        set_title_label();
-                                        zoom_fit_button.sensitive = false;
-                                    });
-                            }
-            
-                            zoom_orig_button = new Button.from_icon_name("zoom-original-symbolic", ICON_SIZE);
-                            {
-                                zoom_orig_button.tooltip_text = _("100%");
-                                zoom_orig_button.get_style_context().add_class("image_overlay_button");
-                                zoom_orig_button.clicked.connect(() => {
-                                        image.zoom_original();
-                                        set_title_label();
-                                        zoom_fit_button.sensitive = true;
-                                    });
-                            }
-            
-                            hflip_button = new Button.from_icon_name("object-flip-horizontal-symbolic", ICON_SIZE);
-                            {
-                                hflip_button.tooltip_text = _("Flip horizontally");
-                                hflip_button.get_style_context().add_class("image_overlay_button");
-                                hflip_button.clicked.connect(() => {
-                                        image.hflip();
-                                    });
-                            }
-            
-                            vflip_button = new Button.from_icon_name("object-flip-vertical-symbolic", ICON_SIZE);
-                            {
-                                vflip_button.tooltip_text = _("Flip vertically");
-                                vflip_button.get_style_context().add_class("image_overlay_button");
-                                vflip_button.clicked.connect(() => {
-                                        image.vflip();
-                                    });
-                            }
-            
-                            lrotate_button = new Button.from_icon_name("object-rotate-left-symbolic", ICON_SIZE);
-                            {
-                                lrotate_button.tooltip_text = _("Rotate to the left");
-                                lrotate_button.get_style_context().add_class("image_overlay_button");
-                                lrotate_button.clicked.connect(() => {
-                                        image.rotate_left();
-                                        set_title_label();
-                                        zoom_fit_button.sensitive = true;
-                                    });
-                            }
+        image_container = new ScrolledWindow(null, null);
+        image_container.add(image);
+        image_container.scroll_child.connect((a, b) => {
+            print("Scroll Event\n");
+            return false;
+        });
 
-                            rrotate_button = new Button.from_icon_name("object-rotate-right-symbolic", ICON_SIZE);
-                            {
-                                rrotate_button.tooltip_text = _("Rotate to the right");
-                                rrotate_button.get_style_context().add_class("image_overlay_button");
-                                rrotate_button.clicked.connect(() => {
-                                        image.rotate_right();
-                                        set_title_label();
-                                        zoom_fit_button.sensitive = true;
-                                    });
-                            }
+        var open_button_icon = new Image.from_icon_name("document-open-symbolic",
+        ICON_SIZE);
 
-                            button_box3.pack_start(zoom_in_button);
-                            button_box3.pack_start(zoom_out_button);
-                            button_box3.pack_start(zoom_fit_button);
-                            button_box3.pack_start(zoom_orig_button);
-                            button_box3.pack_start(hflip_button);
-                            button_box3.pack_start(vflip_button);
-                            button_box3.pack_start(lrotate_button);
-                            button_box3.pack_start(rrotate_button);
-                            button_box3.set_layout(ButtonBoxStyle.EXPAND);
-                            button_box3.margin = 5;
-                        }
-                    
-                        toolbar_hbox.pack_start(button_box1, false, false);
-                        toolbar_hbox.pack_start(button_box3, false, false);
-                        toolbar_hbox.vexpand = false;
-                        toolbar_hbox.valign = Align.START;
-                        toolbar_hbox.get_style_context().add_class("toolbar");
-                    }
-                
-                    toolbar_revealer.add(toolbar_hbox);
-                    toolbar_revealer.transition_type = RevealerTransitionType.SLIDE_DOWN;
-                }
+        open_button = new Button() {
+            tooltip_text = _("Open")
+        };
+        open_button.add(open_button_icon);
+        open_button.clicked.connect(() => {
+            on_open_button_clicked();
+        });
 
-                message_revealer = new Revealer();
-                {
-                    Box message_bar = new Box(Orientation.HORIZONTAL, 0);
-                    {
-                        message_label = new Label("");
-                        {
-                            message_label.get_style_context().add_class("message_label");
-                            message_label.margin = 10;
-                        }
+        save_button = new Button.from_icon_name("document-save-symbolic", ICON_SIZE) {
+            tooltip_text = _("Save as…")
+        };
+        save_button.clicked.connect(() => {
+            on_save_button_clicked();
+        });
 
-                        message_bar.pack_start(message_label);
-                        message_bar.valign = Align.END;
-                        message_bar.hexpand = true;
-                        message_bar.vexpand = false;
-                        message_bar.get_style_context().add_class("message_bar");
-                    }
-                    
-                    message_revealer.add(message_bar);
-                    message_revealer.transition_type = RevealerTransitionType.SLIDE_UP;
-                    message_revealer.transition_duration = 100;
-                    message_revealer.reveal_child = false;
-                }
+        var button_box1 = new ButtonBox(Orientation.HORIZONTAL) {
+            margin = 5
+        };
+        button_box1.add(open_button);
+        button_box1.add(save_button);
+        button_box1.set_layout(ButtonBoxStyle.EXPAND);
 
-                revealer_box.pack_start(toolbar_revealer, false, false);
-                revealer_box.pack_end(message_revealer, false, false);
-            }
+        zoom_in_button = new Button.from_icon_name("zoom-in-symbolic", ICON_SIZE) {
+            tooltip_text = _("Zoom in")
+        };
+        zoom_in_button.get_style_context().add_class("image_overlay_button");
+        zoom_in_button.clicked.connect(() => {
+            image.zoom_in();
+            set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
 
-            window_overlay.add(image_container);
-            window_overlay.add_overlay(revealer_box);
-            window_overlay.set_overlay_pass_through(revealer_box, true);
-        }
+        zoom_out_button = new Button.from_icon_name("zoom-out-symbolic", ICON_SIZE) {
+            tooltip_text = _("Zoom out")
+        };
+        zoom_out_button.get_style_context().add_class("image_overlay_button");
+        zoom_out_button.clicked.connect(() => {
+            image.zoom_out();
+            set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        zoom_fit_button = new Button.from_icon_name("zoom-fit-best-symbolic", ICON_SIZE) {
+            tooltip_text = _("Fit to the page")
+        };
+        zoom_fit_button.get_style_context().add_class("image_overlay_button");
+        zoom_fit_button.clicked.connect(() => {
+            image.fit_image_to_window();
+            set_title_label();
+            zoom_fit_button.sensitive = false;
+        });
+
+        zoom_orig_button = new Button.from_icon_name("zoom-original-symbolic", ICON_SIZE) {
+            tooltip_text = _("100%")
+        };
+        zoom_orig_button.get_style_context().add_class("image_overlay_button");
+        zoom_orig_button.clicked.connect(() => {
+            image.zoom_original();
+            set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        hflip_button = new Button.from_icon_name("object-flip-horizontal-symbolic", ICON_SIZE) {
+            tooltip_text = _("Flip horizontally")
+        };
+        hflip_button.get_style_context().add_class("image_overlay_button");
+        hflip_button.clicked.connect(() => {
+            image.hflip();
+        });
+
+        vflip_button = new Button.from_icon_name("object-flip-vertical-symbolic", ICON_SIZE) {
+            tooltip_text = _("Flip vertically")
+        };
+        vflip_button.get_style_context().add_class("image_overlay_button");
+        vflip_button.clicked.connect(() => {
+            image.vflip();
+        });
+
+        lrotate_button = new Button.from_icon_name("object-rotate-left-symbolic", ICON_SIZE) {
+            tooltip_text = _("Rotate to the left")
+        };
+        lrotate_button.get_style_context().add_class("image_overlay_button");
+        lrotate_button.clicked.connect(() => {
+            image.rotate_left();
+            set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        rrotate_button = new Button.from_icon_name("object-rotate-right-symbolic", ICON_SIZE) {
+            tooltip_text = _("Rotate to the right")
+        };
+        rrotate_button.get_style_context().add_class("image_overlay_button");
+        rrotate_button.clicked.connect(() => {
+            image.rotate_right();
+            set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        var button_box3 = new ButtonBox(Orientation.HORIZONTAL) {
+            margin = 5
+        };
+        button_box3.pack_start(zoom_in_button);
+        button_box3.pack_start(zoom_out_button);
+        button_box3.pack_start(zoom_fit_button);
+        button_box3.pack_start(zoom_orig_button);
+        button_box3.pack_start(hflip_button);
+        button_box3.pack_start(vflip_button);
+        button_box3.pack_start(lrotate_button);
+        button_box3.pack_start(rrotate_button);
+        button_box3.set_layout(ButtonBoxStyle.EXPAND);
+
+        var toolbar_hbox = new Box(Orientation.HORIZONTAL, 0) {
+            vexpand = false,
+            valign = Align.START
+        };
+        toolbar_hbox.pack_start(button_box1, false, false);
+        toolbar_hbox.pack_start(button_box3, false, false);
+        toolbar_hbox.get_style_context().add_class("toolbar");
+
+        toolbar_revealer = new Revealer() {
+            transition_type = RevealerTransitionType.SLIDE_DOWN
+        };
+        toolbar_revealer.add(toolbar_hbox);
+
+        message_label = new Label("") {
+            margin = 10
+        };
+        message_label.get_style_context().add_class("message_label");
+
+        var message_bar = new Box(Orientation.HORIZONTAL, 0) {
+            valign = Align.END,
+            hexpand = true,
+            vexpand = false
+        };
+        message_bar.pack_start(message_label);
+        message_bar.get_style_context().add_class("message_bar");
+
+        message_revealer = new Revealer() {
+            transition_type = RevealerTransitionType.SLIDE_UP,
+            transition_duration = 100,
+            reveal_child = false
+        };
+        message_revealer.add(message_bar);
+
+        var revealer_box = new Box(Orientation.VERTICAL, 0);
+        revealer_box.pack_start(toolbar_revealer, false, false);
+        revealer_box.pack_end(message_revealer, false, false);
+
+        var window_overlay = new Overlay();
+        window_overlay.add(image_container);
+        window_overlay.add_overlay(revealer_box);
+        window_overlay.set_overlay_pass_through(revealer_box, true);
 
         Idle.add(() => {
-                if (file_list != null) {
-                    if (file_list.size == 0) {
-                        image_prev_button.sensitive = false;
-                        image_next_button.sensitive = false;
-                    } else {
-                        image_prev_button.sensitive = !file_list.file_is_first(true);
-                        image_next_button.sensitive = !file_list.file_is_last(true);
-                    }
+            if (file_list != null) {
+                if (file_list.size == 0) {
+                    image_prev_button.sensitive = false;
+                    image_next_button.sensitive = false;
+                } else {
+                    image_prev_button.sensitive = !file_list.file_is_first(true);
+                    image_next_button.sensitive = !file_list.file_is_last(true);
                 }
-                return Source.CONTINUE;
-            });
+            }
+
+            return Source.CONTINUE;
+        });
         
         set_titlebar(headerbar);
         add(window_overlay);
         set_default_size(800, 600);
         event.connect((ev) => {
-                return handle_events(ev);
-            });
+            return handle_events(ev);
+        });
         configure_event.connect((cr) => {
-                if (image.fit) {
-                    debug("window::configure_event -> image.fit_image_to_window");
-                    image.fit_image_to_window();
-                    set_title_label();
-                }
-                return false;
-            });
+            if (image.fit) {
+                debug("window::configure_event -> image.fit_image_to_window");
+                image.fit_image_to_window();
+                set_title_label();
+            }
+            return false;
+        });
         destroy.connect(Gtk.main_quit);
 
         setup_css();

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -46,27 +46,16 @@ public class TatapWindow : Gtk.Window {
     private const string title_format = "%s (%dx%d : %.2f%%)";
     
     private HeaderBar headerbar;
-    private Button open_button;
-    private Button save_button;
 
     private NavigationBox navigation_box;
     
-    private Button zoom_in_button;
-    private Button zoom_out_button;
-    private Button zoom_fit_button;
-    private Button zoom_orig_button;
-    private Button hflip_button;
-    private Button vflip_button;
-    private Button lrotate_button;
-    private Button rrotate_button;
-
     private ScrolledWindow image_container;
     public TatapImage image { get; private set; }
     private Revealer message_revealer;
     private Label message_label;
     
     private Revealer toolbar_revealer;
-    
+
     public TatapFileList? file_list { get; private set; default = null; }
 
     private bool button_pressed = false;
@@ -74,8 +63,10 @@ public class TatapWindow : Gtk.Window {
     private double y;
 
     public TatapWindow() {
-        navigation_box = new NavigationBox (this);
+        /* previous/next buttons at the left of the headerbar */
+        navigation_box = new NavigationBox(this);
 
+        /* menu button at the right of the headerbar */
         var toggle_toolbar_icon = new Image.from_icon_name("view-more-symbolic", ICON_SIZE);
         var toolbar_toggle_button = new ToggleButton() {
             tooltip_text = _("Menu")
@@ -89,12 +80,14 @@ public class TatapWindow : Gtk.Window {
         header_button_box_right.add(toolbar_toggle_button);
         header_button_box_right.set_layout(ButtonBoxStyle.EXPAND);
 
+        /* the headerbar itself */
         headerbar = new HeaderBar() {
             show_close_button = true
         };
         headerbar.pack_start(navigation_box);
         headerbar.pack_end(header_button_box_right);
 
+        /* image area in the center of the window */
         image = new TatapImage(true);
         image.get_style_context().add_class("image-view");
 
@@ -105,133 +98,10 @@ public class TatapWindow : Gtk.Window {
             return false;
         });
 
-        var open_button_icon = new Image.from_icon_name("document-open-symbolic",
-        ICON_SIZE);
+        /* contain buttons that can be opened from the menu */
+        toolbar_revealer = new ToolBarRevealer(this);
 
-        open_button = new Button() {
-            tooltip_text = _("Open")
-        };
-        open_button.add(open_button_icon);
-        open_button.clicked.connect(() => {
-            on_open_button_clicked();
-        });
-
-        save_button = new Button.from_icon_name("document-save-symbolic", ICON_SIZE) {
-            tooltip_text = _("Save as…")
-        };
-        save_button.clicked.connect(() => {
-            on_save_button_clicked();
-        });
-
-        var button_box1 = new ButtonBox(Orientation.HORIZONTAL) {
-            margin = 5
-        };
-        button_box1.add(open_button);
-        button_box1.add(save_button);
-        button_box1.set_layout(ButtonBoxStyle.EXPAND);
-
-        zoom_in_button = new Button.from_icon_name("zoom-in-symbolic", ICON_SIZE) {
-            tooltip_text = _("Zoom in")
-        };
-        zoom_in_button.get_style_context().add_class("image_overlay_button");
-        zoom_in_button.clicked.connect(() => {
-            image.zoom_in();
-            set_title_label();
-            zoom_fit_button.sensitive = true;
-        });
-
-        zoom_out_button = new Button.from_icon_name("zoom-out-symbolic", ICON_SIZE) {
-            tooltip_text = _("Zoom out")
-        };
-        zoom_out_button.get_style_context().add_class("image_overlay_button");
-        zoom_out_button.clicked.connect(() => {
-            image.zoom_out();
-            set_title_label();
-            zoom_fit_button.sensitive = true;
-        });
-
-        zoom_fit_button = new Button.from_icon_name("zoom-fit-best-symbolic", ICON_SIZE) {
-            tooltip_text = _("Fit to the page")
-        };
-        zoom_fit_button.get_style_context().add_class("image_overlay_button");
-        zoom_fit_button.clicked.connect(() => {
-            image.fit_image_to_window();
-            set_title_label();
-            zoom_fit_button.sensitive = false;
-        });
-
-        zoom_orig_button = new Button.from_icon_name("zoom-original-symbolic", ICON_SIZE) {
-            tooltip_text = _("100%")
-        };
-        zoom_orig_button.get_style_context().add_class("image_overlay_button");
-        zoom_orig_button.clicked.connect(() => {
-            image.zoom_original();
-            set_title_label();
-            zoom_fit_button.sensitive = true;
-        });
-
-        hflip_button = new Button.from_icon_name("object-flip-horizontal-symbolic", ICON_SIZE) {
-            tooltip_text = _("Flip horizontally")
-        };
-        hflip_button.get_style_context().add_class("image_overlay_button");
-        hflip_button.clicked.connect(() => {
-            image.hflip();
-        });
-
-        vflip_button = new Button.from_icon_name("object-flip-vertical-symbolic", ICON_SIZE) {
-            tooltip_text = _("Flip vertically")
-        };
-        vflip_button.get_style_context().add_class("image_overlay_button");
-        vflip_button.clicked.connect(() => {
-            image.vflip();
-        });
-
-        lrotate_button = new Button.from_icon_name("object-rotate-left-symbolic", ICON_SIZE) {
-            tooltip_text = _("Rotate to the left")
-        };
-        lrotate_button.get_style_context().add_class("image_overlay_button");
-        lrotate_button.clicked.connect(() => {
-            image.rotate_left();
-            set_title_label();
-            zoom_fit_button.sensitive = true;
-        });
-
-        rrotate_button = new Button.from_icon_name("object-rotate-right-symbolic", ICON_SIZE) {
-            tooltip_text = _("Rotate to the right")
-        };
-        rrotate_button.get_style_context().add_class("image_overlay_button");
-        rrotate_button.clicked.connect(() => {
-            image.rotate_right();
-            set_title_label();
-            zoom_fit_button.sensitive = true;
-        });
-
-        var button_box3 = new ButtonBox(Orientation.HORIZONTAL) {
-            margin = 5
-        };
-        button_box3.pack_start(zoom_in_button);
-        button_box3.pack_start(zoom_out_button);
-        button_box3.pack_start(zoom_fit_button);
-        button_box3.pack_start(zoom_orig_button);
-        button_box3.pack_start(hflip_button);
-        button_box3.pack_start(vflip_button);
-        button_box3.pack_start(lrotate_button);
-        button_box3.pack_start(rrotate_button);
-        button_box3.set_layout(ButtonBoxStyle.EXPAND);
-
-        var toolbar_hbox = new Box(Orientation.HORIZONTAL, 0) {
-            vexpand = false,
-            valign = Align.START
-        };
-        toolbar_hbox.pack_start(button_box1, false, false);
-        toolbar_hbox.pack_start(button_box3, false, false);
-        toolbar_hbox.get_style_context().add_class("toolbar");
-
-        toolbar_revealer = new Revealer() {
-            transition_type = RevealerTransitionType.SLIDE_DOWN
-        };
-        toolbar_revealer.add(toolbar_hbox);
-
+        /* revealer showing error messages */
         message_label = new Label("") {
             margin = 10
         };
@@ -256,10 +126,13 @@ public class TatapWindow : Gtk.Window {
         revealer_box.pack_start(toolbar_revealer, false, false);
         revealer_box.pack_end(message_revealer, false, false);
 
+        /* Add images and revealer into overlay */
         var window_overlay = new Overlay();
         window_overlay.add(image_container);
         window_overlay.add_overlay(revealer_box);
         window_overlay.set_overlay_pass_through(revealer_box, true);
+
+        add(window_overlay);
 
         Idle.add(() => {
             if (file_list != null) {
@@ -276,7 +149,6 @@ public class TatapWindow : Gtk.Window {
         });
         
         set_titlebar(headerbar);
-        add(window_overlay);
         set_default_size(800, 600);
         event.connect((ev) => {
             return handle_events(ev);
@@ -330,7 +202,7 @@ public class TatapWindow : Gtk.Window {
         return false;
     }
 
-    private void set_title_label() {
+    public void set_title_label() {
         if (image.has_image) {
             string title = title_format.printf(image.fileref.get_basename(),
                                                image.original_width,
@@ -390,7 +262,7 @@ public class TatapWindow : Gtk.Window {
         }
     }
 
-    private void save_file(string filename) {
+    public void save_file(string filename) {
         debug("The file name for save: %s", filename);
         File file = File.new_for_path(filename);
         string full_path = file.get_path();
@@ -433,29 +305,5 @@ public class TatapWindow : Gtk.Window {
         } catch (Error e) {
             stderr.printf("Error: %s\n", e.message);
         }
-    }
-    
-    private void on_open_button_clicked() {
-        FileChooserDialog dialog = new FileChooserDialog(_("Choose file to open"), this, FileChooserAction.OPEN,
-                                           _("Cancel"), ResponseType.CANCEL,
-                                           _("Open"), ResponseType.ACCEPT);
-        int res = dialog.run();
-        if (res == ResponseType.ACCEPT) {
-            string filename = dialog.get_filename();
-            open_file(filename);
-        }
-        dialog.close();
-    }
-
-    private void on_save_button_clicked() {
-        FileChooserDialog dialog = new FileChooserDialog(_("Save as…"), this, FileChooserAction.SAVE,
-                                           _("Cancel"), ResponseType.CANCEL,
-                                           _("Open"), ResponseType.ACCEPT);
-        int res = dialog.run();
-        if (res == ResponseType.ACCEPT) {
-            string filename = dialog.get_filename();
-            save_file(filename);
-        }
-        dialog.close();
     }
 }

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -76,9 +76,10 @@ public class TatapWindow : Gtk.Window {
             toolbar_revealer.reveal_child = toolbar_toggle_button.active;
         });
 
-        var header_button_box_right = new ButtonBox(Orientation.HORIZONTAL);
+        var header_button_box_right = new ButtonBox(Orientation.HORIZONTAL) {
+            layout_style = ButtonBoxStyle.EXPAND
+        };
         header_button_box_right.add(toolbar_toggle_button);
-        header_button_box_right.set_layout(ButtonBoxStyle.EXPAND);
 
         /* the headerbar itself */
         headerbar = new HeaderBar() {

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -168,36 +168,36 @@ public class TatapWindow : Gtk.Window {
 
     private bool handle_events(Event ev) {
         switch (ev.type) {
-        case EventType.BUTTON_PRESS:
-            button_pressed = true;
-            x = ev.motion.x_root;
-            y = ev.motion.y_root;
-            break;
-        case EventType.BUTTON_RELEASE:
-            button_pressed = false;
-            break;
-        case EventType.MOTION_NOTIFY:
-            if (button_pressed) {
-                double new_x = ev.motion.x_root;
-                double new_y = ev.motion.y_root;
-                int x_move = (int) (new_x - x);
-                int y_move = (int) (new_y - y);
-                image_container.hadjustment.value -= x_move;
-                image_container.vadjustment.value -= y_move;
-                x = new_x;
-                y = new_y;
-            }
-            break;
-        case EventType.SCROLL:
-            if (ev.scroll.state == ModifierType.CONTROL_MASK) {
-                if (ev.scroll.direction == ScrollDirection.UP) {
-                    image.zoom_out();
-                } else if (ev.scroll.direction == ScrollDirection.DOWN) {
-                    image.zoom_in();
+            case EventType.BUTTON_PRESS:
+                button_pressed = true;
+                x = ev.motion.x_root;
+                y = ev.motion.y_root;
+                break;
+            case EventType.BUTTON_RELEASE:
+                button_pressed = false;
+                break;
+            case EventType.MOTION_NOTIFY:
+                if (button_pressed) {
+                    double new_x = ev.motion.x_root;
+                    double new_y = ev.motion.y_root;
+                    int x_move = (int) (new_x - x);
+                    int y_move = (int) (new_y - y);
+                    image_container.hadjustment.value -= x_move;
+                    image_container.vadjustment.value -= y_move;
+                    x = new_x;
+                    y = new_y;
                 }
-                return true;
-            }
-            break;
+                break;
+            case EventType.SCROLL:
+                if (ev.scroll.state == ModifierType.CONTROL_MASK) {
+                    if (ev.scroll.direction == ScrollDirection.UP) {
+                        image.zoom_out();
+                    } else if (ev.scroll.direction == ScrollDirection.DOWN) {
+                        image.zoom_in();
+                    }
+                    return true;
+                }
+                break;
         }
         return false;
     }
@@ -235,20 +235,20 @@ public class TatapWindow : Gtk.Window {
             if (old_file_dir == null || old_file_dir != new_file_dir) {
                 file_list = new TatapFileList();
                 file_list.directory_not_found.connect(() => {
-                        DialogFlags flags = DialogFlags.MODAL;
-                        MessageDialog alert = new MessageDialog(this, flags, MessageType.ERROR,
-                                                      ButtonsType.OK, _("The directory does not found. Exiting."));
-                        alert.run();
-                        alert.close();
-                        Gtk.main_quit();
-                    });
+                    DialogFlags flags = DialogFlags.MODAL;
+                    MessageDialog alert = new MessageDialog(this, flags, MessageType.ERROR,
+                                                    ButtonsType.OK, _("The directory does not found. Exiting."));
+                    alert.run();
+                    alert.close();
+                    Gtk.main_quit();
+                });
                 file_list.file_not_found.connect(() => {
-                        DialogFlags flags = DialogFlags.MODAL;
-                        MessageDialog alert = new MessageDialog(this, flags, MessageType.ERROR,
-                                                      ButtonsType.OK, _("The file does not found."));
-                        alert.run();
-                        alert.close();
-                    });
+                    DialogFlags flags = DialogFlags.MODAL;
+                    MessageDialog alert = new MessageDialog(this, flags, MessageType.ERROR,
+                                                    ButtonsType.OK, _("The file does not found."));
+                    alert.run();
+                    alert.close();
+                });
                 file_list.make_list(image.fileref.get_parent().get_path());
             }
             file_list.set_current(image.fileref);
@@ -284,14 +284,14 @@ public class TatapWindow : Gtk.Window {
             if (TatapFileType.is_valid_extension(extension)) {
                 pixbuf.save(full_path, TatapFileType.to_pixbuf_type(extension)); // TODO other parameters will be required.
                 Idle.add(() => {
-                        message_label.label = _("The file is saved.");
-                        message_revealer.reveal_child = true;
-                        Timeout.add(2000, () => {
-                                message_revealer.reveal_child = false;
-                                return Source.REMOVE;
-                            });
+                    message_label.label = _("The file is saved.");
+                    message_revealer.reveal_child = true;
+                    Timeout.add(2000, () => {
+                        message_revealer.reveal_child = false;
                         return Source.REMOVE;
                     });
+                    return Source.REMOVE;
+                });
             } else {
                 throw new TatapError.INVALID_EXTENSION(extension);
             }

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -44,16 +44,16 @@ public class TatapWindow : Gtk.Window {
     """;
 
     private const string title_format = "%s (%dx%d : %.2f%%)";
-    
+
     private HeaderBar headerbar;
 
     private NavigationBox navigation_box;
-    
+
     private ScrolledWindow image_container;
     public TatapImage image { get; private set; }
     private Revealer message_revealer;
     private Label message_label;
-    
+
     private Revealer toolbar_revealer;
 
     public TatapFileList? file_list { get; private set; default = null; }
@@ -148,7 +148,7 @@ public class TatapWindow : Gtk.Window {
 
             return Source.CONTINUE;
         });
-        
+
         set_titlebar(headerbar);
         set_default_size(800, 600);
         event.connect((ev) => {
@@ -223,13 +223,13 @@ public class TatapWindow : Gtk.Window {
             stderr.printf("CssProvider loading failed!\n");
         }
     }
-    
+
     public void open_file(string filename) {
         string? old_file_dir = null;
         if (image.fileref != null) {
             old_file_dir = image.fileref.get_parent().get_path();
         }
-        
+
         try {
             image.open(filename);
             string new_file_dir = image.fileref.get_parent().get_path();
@@ -277,7 +277,7 @@ public class TatapWindow : Gtk.Window {
                 return;
             }
         }
-        
+
         Pixbuf pixbuf = image.pixbuf;
         string[] tmp = full_path.split(".");
         try {

--- a/src/Widgets/NavigationBox.vala
+++ b/src/Widgets/NavigationBox.vala
@@ -25,7 +25,8 @@ public class NavigationBox : Gtk.ButtonBox {
     public NavigationBox (TatapWindow window) {
         Object (
             window: window,
-            orientation: Gtk.Orientation.HORIZONTAL
+            orientation: Gtk.Orientation.HORIZONTAL,
+            layout_style: Gtk.ButtonBoxStyle.EXPAND
         );
     }
 
@@ -63,7 +64,6 @@ public class NavigationBox : Gtk.ButtonBox {
 
         add(image_prev_button);
         add(image_next_button);
-        set_layout(Gtk.ButtonBoxStyle.EXPAND);
     }
 
     public void set_image_prev_button_sensitivity(bool is_sensitive) {

--- a/src/Widgets/NavigationBox.vala
+++ b/src/Widgets/NavigationBox.vala
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2019-2020 Tanaka Takayuki (田中喬之) 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Tanaka Takayuki <msg@gorigorilinux.net>
+ */
+
+public class NavigationBox : Gtk.ButtonBox {
+    public TatapWindow window { get; construct; }
+
+    private Gtk.Button image_prev_button;
+    private Gtk.Button image_next_button;
+
+    public NavigationBox (TatapWindow window) {
+        Object (
+            window: window,
+            orientation: Gtk.Orientation.HORIZONTAL
+        );
+    }
+
+    construct {
+        image_prev_button = new Gtk.Button.from_icon_name("go-previous-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            valign = Gtk.Align.CENTER,
+            tooltip_text = _("Previous")
+        };
+        image_prev_button.get_style_context().add_class("image_button");
+        image_prev_button.clicked.connect(() => {
+            if (window.file_list != null) {
+                File? prev_file = window.file_list.get_prev_file(window.image.fileref);
+
+                if (prev_file != null) {
+                    window.open_file(prev_file.get_path());
+                }
+            }
+        });
+
+        image_next_button = new Gtk.Button.from_icon_name("go-next-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            valign = Gtk.Align.CENTER,
+            tooltip_text = _("Next")
+        };
+        image_next_button.get_style_context().add_class("image_button");
+        image_next_button.clicked.connect(() => {
+            if (window.file_list != null) {
+                File? next_file = window.file_list.get_next_file(window.image.fileref);
+                debug("next file: %s", next_file.get_basename());
+
+                if (next_file != null) {
+                    window.open_file(next_file.get_path());
+                }
+            }
+        });
+
+        add(image_prev_button);
+        add(image_next_button);
+        set_layout(Gtk.ButtonBoxStyle.EXPAND);
+    }
+
+    public void set_image_prev_button_sensitivity(bool is_sensitive) {
+        image_prev_button.sensitive = is_sensitive;
+    }
+
+    public void set_image_next_button_sensitivity(bool is_sensitive) {
+        image_next_button.sensitive = is_sensitive;
+    }
+}

--- a/src/Widgets/NavigationBox.vala
+++ b/src/Widgets/NavigationBox.vala
@@ -26,15 +26,13 @@ public class NavigationBox : Gtk.ButtonBox {
         Object (
             window: window,
             orientation: Gtk.Orientation.HORIZONTAL,
-            layout_style: Gtk.ButtonBoxStyle.EXPAND
+            layout_style: Gtk.ButtonBoxStyle.EXPAND,
+            valign: Gtk.Align.CENTER
         );
     }
 
     construct {
-        image_prev_button = new Gtk.Button.from_icon_name("go-previous-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            valign = Gtk.Align.CENTER,
-            tooltip_text = _("Previous")
-        };
+        image_prev_button = new ToolButton("go-previous-symbolic", _("Previous"));
         image_prev_button.get_style_context().add_class("image_button");
         image_prev_button.clicked.connect(() => {
             if (window.file_list != null) {
@@ -46,10 +44,7 @@ public class NavigationBox : Gtk.ButtonBox {
             }
         });
 
-        image_next_button = new Gtk.Button.from_icon_name("go-next-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            valign = Gtk.Align.CENTER,
-            tooltip_text = _("Next")
-        };
+        image_next_button = new ToolButton("go-next-symbolic", _("Next"));
         image_next_button.get_style_context().add_class("image_button");
         image_next_button.clicked.connect(() => {
             if (window.file_list != null) {

--- a/src/Widgets/ToolBarRevealer.vala
+++ b/src/Widgets/ToolBarRevealer.vala
@@ -30,16 +30,12 @@ public class ToolBarRevealer : Gtk.Revealer {
 
     construct {
         /* action buttons for file */
-        var open_button = new Gtk.Button.from_icon_name("document-open-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Open")
-        };
+        var open_button = new ToolButton("document-open-symbolic", _("Open"));
         open_button.clicked.connect(() => {
             on_open_button_clicked();
         });
 
-        var save_button = new Gtk.Button.from_icon_name("document-save-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Save as…")
-        };
+        var save_button = new ToolButton("document-save-symbolic", _("Save as…"));
         save_button.clicked.connect(() => {
             on_save_button_clicked();
         });
@@ -52,9 +48,7 @@ public class ToolBarRevealer : Gtk.Revealer {
         file_action_button_box.add(save_button);
 
         /* action buttons for the image */
-        var zoom_in_button = new Gtk.Button.from_icon_name("zoom-in-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Zoom in")
-        };
+        var zoom_in_button = new ToolButton("zoom-in-symbolic", _("Zoom in"));
         zoom_in_button.get_style_context().add_class("image_overlay_button");
         zoom_in_button.clicked.connect(() => {
             window.image.zoom_in();
@@ -62,9 +56,7 @@ public class ToolBarRevealer : Gtk.Revealer {
             zoom_fit_button.sensitive = true;
         });
 
-        var zoom_out_button = new Gtk.Button.from_icon_name("zoom-out-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Zoom out")
-        };
+        var zoom_out_button = new ToolButton("zoom-out-symbolic", _("Zoom out"));
         zoom_out_button.get_style_context().add_class("image_overlay_button");
         zoom_out_button.clicked.connect(() => {
             window.image.zoom_out();
@@ -72,9 +64,7 @@ public class ToolBarRevealer : Gtk.Revealer {
             zoom_fit_button.sensitive = true;
         });
 
-        zoom_fit_button = new Gtk.Button.from_icon_name("zoom-fit-best-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Fit to the page")
-        };
+        zoom_fit_button = new ToolButton("zoom-fit-best-symbolic", _("Fit to the page"));
         zoom_fit_button.get_style_context().add_class("image_overlay_button");
         zoom_fit_button.clicked.connect(() => {
             window.image.fit_image_to_window();
@@ -82,9 +72,7 @@ public class ToolBarRevealer : Gtk.Revealer {
             zoom_fit_button.sensitive = false;
         });
 
-        var zoom_orig_button = new Gtk.Button.from_icon_name("zoom-original-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("100%")
-        };
+        var zoom_orig_button = new ToolButton("zoom-original-symbolic", _("100%"));
         zoom_orig_button.get_style_context().add_class("image_overlay_button");
         zoom_orig_button.clicked.connect(() => {
             window.image.zoom_original();
@@ -92,25 +80,19 @@ public class ToolBarRevealer : Gtk.Revealer {
             zoom_fit_button.sensitive = true;
         });
 
-        var hflip_button = new Gtk.Button.from_icon_name("object-flip-horizontal-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Flip horizontally")
-        };
+        var hflip_button = new ToolButton("object-flip-horizontal-symbolic", _("Flip horizontally"));
         hflip_button.get_style_context().add_class("image_overlay_button");
         hflip_button.clicked.connect(() => {
             window.image.hflip();
         });
 
-        var vflip_button = new Gtk.Button.from_icon_name("object-flip-vertical-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Flip vertically")
-        };
+        var vflip_button = new ToolButton("object-flip-vertical-symbolic", _("Flip vertically"));
         vflip_button.get_style_context().add_class("image_overlay_button");
         vflip_button.clicked.connect(() => {
             window.image.vflip();
         });
 
-        var lrotate_button = new Gtk.Button.from_icon_name("object-rotate-left-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Rotate to the left")
-        };
+        var lrotate_button = new ToolButton("object-rotate-left-symbolic", _("Rotate to the left"));
         lrotate_button.get_style_context().add_class("image_overlay_button");
         lrotate_button.clicked.connect(() => {
             window.image.rotate_left();
@@ -118,9 +100,7 @@ public class ToolBarRevealer : Gtk.Revealer {
             zoom_fit_button.sensitive = true;
         });
 
-        var rrotate_button = new Gtk.Button.from_icon_name("object-rotate-right-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
-            tooltip_text = _("Rotate to the right")
-        };
+        var rrotate_button = new ToolButton("object-rotate-right-symbolic", _("Rotate to the right"));
         rrotate_button.get_style_context().add_class("image_overlay_button");
         rrotate_button.clicked.connect(() => {
             window.image.rotate_right();

--- a/src/Widgets/ToolBarRevealer.vala
+++ b/src/Widgets/ToolBarRevealer.vala
@@ -1,0 +1,178 @@
+/*
+ *  Copyright 2019-2020 Tanaka Takayuki (田中喬之) 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Tanaka Takayuki <msg@gorigorilinux.net>
+ */
+
+public class ToolBarRevealer : Gtk.Revealer {
+    public TatapWindow window { get; construct; }
+
+    private Gtk.Button zoom_fit_button;
+
+    public ToolBarRevealer (TatapWindow window) {
+        Object (
+            window: window,
+            transition_type: Gtk.RevealerTransitionType.SLIDE_DOWN
+        );
+    }
+
+    construct {
+        /* action buttons for file */
+        var open_button = new Gtk.Button.from_icon_name("document-open-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Open")
+        };
+        open_button.clicked.connect(() => {
+            on_open_button_clicked();
+        });
+
+        var save_button = new Gtk.Button.from_icon_name("document-save-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Save as…")
+        };
+        save_button.clicked.connect(() => {
+            on_save_button_clicked();
+        });
+
+        var file_action_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
+            margin = 5
+        };
+        file_action_button_box.add(open_button);
+        file_action_button_box.add(save_button);
+        file_action_button_box.set_layout(Gtk.ButtonBoxStyle.EXPAND);
+
+        /* action buttons for the image */
+        var zoom_in_button = new Gtk.Button.from_icon_name("zoom-in-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Zoom in")
+        };
+        zoom_in_button.get_style_context().add_class("image_overlay_button");
+        zoom_in_button.clicked.connect(() => {
+            window.image.zoom_in();
+            window.set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        var zoom_out_button = new Gtk.Button.from_icon_name("zoom-out-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Zoom out")
+        };
+        zoom_out_button.get_style_context().add_class("image_overlay_button");
+        zoom_out_button.clicked.connect(() => {
+            window.image.zoom_out();
+            window.set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        zoom_fit_button = new Gtk.Button.from_icon_name("zoom-fit-best-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Fit to the page")
+        };
+        zoom_fit_button.get_style_context().add_class("image_overlay_button");
+        zoom_fit_button.clicked.connect(() => {
+            window.image.fit_image_to_window();
+            window.set_title_label();
+            zoom_fit_button.sensitive = false;
+        });
+
+        var zoom_orig_button = new Gtk.Button.from_icon_name("zoom-original-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("100%")
+        };
+        zoom_orig_button.get_style_context().add_class("image_overlay_button");
+        zoom_orig_button.clicked.connect(() => {
+            window.image.zoom_original();
+            window.set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        var hflip_button = new Gtk.Button.from_icon_name("object-flip-horizontal-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Flip horizontally")
+        };
+        hflip_button.get_style_context().add_class("image_overlay_button");
+        hflip_button.clicked.connect(() => {
+            window.image.hflip();
+        });
+
+        var vflip_button = new Gtk.Button.from_icon_name("object-flip-vertical-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Flip vertically")
+        };
+        vflip_button.get_style_context().add_class("image_overlay_button");
+        vflip_button.clicked.connect(() => {
+            window.image.vflip();
+        });
+
+        var lrotate_button = new Gtk.Button.from_icon_name("object-rotate-left-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Rotate to the left")
+        };
+        lrotate_button.get_style_context().add_class("image_overlay_button");
+        lrotate_button.clicked.connect(() => {
+            window.image.rotate_left();
+            window.set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        var rrotate_button = new Gtk.Button.from_icon_name("object-rotate-right-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
+            tooltip_text = _("Rotate to the right")
+        };
+        rrotate_button.get_style_context().add_class("image_overlay_button");
+        rrotate_button.clicked.connect(() => {
+            window.image.rotate_right();
+            window.set_title_label();
+            zoom_fit_button.sensitive = true;
+        });
+
+        var image_actions_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
+            margin = 5
+        };
+        image_actions_button_box.pack_start(zoom_in_button);
+        image_actions_button_box.pack_start(zoom_out_button);
+        image_actions_button_box.pack_start(zoom_fit_button);
+        image_actions_button_box.pack_start(zoom_orig_button);
+        image_actions_button_box.pack_start(hflip_button);
+        image_actions_button_box.pack_start(vflip_button);
+        image_actions_button_box.pack_start(lrotate_button);
+        image_actions_button_box.pack_start(rrotate_button);
+        image_actions_button_box.set_layout(Gtk.ButtonBoxStyle.EXPAND);
+
+        var toolbar_hbox = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0) {
+            vexpand = false,
+            valign = Gtk.Align.START
+        };
+        toolbar_hbox.pack_start(file_action_button_box, false, false);
+        toolbar_hbox.pack_start(image_actions_button_box, false, false);
+        toolbar_hbox.get_style_context().add_class("toolbar");
+
+        add(toolbar_hbox);
+    }
+
+    private void on_open_button_clicked() {
+        var dialog = new Gtk.FileChooserDialog(_("Choose file to open"), window, Gtk.FileChooserAction.OPEN,
+                                           _("Cancel"), Gtk.ResponseType.CANCEL,
+                                           _("Open"), Gtk.ResponseType.ACCEPT);
+        int res = dialog.run();
+        if (res == Gtk.ResponseType.ACCEPT) {
+            string filename = dialog.get_filename();
+            window.open_file(filename);
+        }
+        dialog.close();
+    }
+
+    private void on_save_button_clicked() {
+        var dialog = new Gtk.FileChooserDialog(_("Save as…"), window, Gtk.FileChooserAction.SAVE,
+                                           _("Cancel"), Gtk.ResponseType.CANCEL,
+                                           _("Open"), Gtk.ResponseType.ACCEPT);
+        int res = dialog.run();
+        if (res == Gtk.ResponseType.ACCEPT) {
+            string filename = dialog.get_filename();
+            window.save_file(filename);
+        }
+        dialog.close();
+    }
+}

--- a/src/Widgets/ToolBarRevealer.vala
+++ b/src/Widgets/ToolBarRevealer.vala
@@ -45,11 +45,11 @@ public class ToolBarRevealer : Gtk.Revealer {
         });
 
         var file_action_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
-            margin = 5
+            margin = 5,
+            layout_style = Gtk.ButtonBoxStyle.EXPAND
         };
         file_action_button_box.add(open_button);
         file_action_button_box.add(save_button);
-        file_action_button_box.set_layout(Gtk.ButtonBoxStyle.EXPAND);
 
         /* action buttons for the image */
         var zoom_in_button = new Gtk.Button.from_icon_name("zoom-in-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
@@ -129,7 +129,8 @@ public class ToolBarRevealer : Gtk.Revealer {
         });
 
         var image_actions_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
-            margin = 5
+            margin = 5,
+            layout_style = Gtk.ButtonBoxStyle.EXPAND
         };
         image_actions_button_box.pack_start(zoom_in_button);
         image_actions_button_box.pack_start(zoom_out_button);
@@ -139,7 +140,6 @@ public class ToolBarRevealer : Gtk.Revealer {
         image_actions_button_box.pack_start(vflip_button);
         image_actions_button_box.pack_start(lrotate_button);
         image_actions_button_box.pack_start(rrotate_button);
-        image_actions_button_box.set_layout(Gtk.ButtonBoxStyle.EXPAND);
 
         var toolbar_hbox = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0) {
             vexpand = false,

--- a/src/Widgets/ToolButton.vala
+++ b/src/Widgets/ToolButton.vala
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2019-2020 Tanaka Takayuki (田中喬之) 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Tanaka Takayuki <msg@gorigorilinux.net>
+ */
+
+public class ToolButton : Gtk.Button {
+    public string icon_name { get; construct; }
+
+    public ToolButton (string icon_name, string tooltip_text) {
+        Object (
+            icon_name: icon_name,
+            tooltip_text: tooltip_text
+        );
+    }
+
+    construct {
+        add(new Gtk.Image.from_icon_name(icon_name, Gtk.IconSize.SMALL_TOOLBAR));
+    }
+}


### PR DESCRIPTION
- Split TatapWindow class into NavigationBox and ToolBarRevealer to fix long lines in TatapWindow.vala
- Fix indentation
- Fix coding style (e.g. use `var` instead of explicating types)
