### PR TITLE
Load CSS using gresource

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,0 +1,15 @@
+.image-view {
+    background-color: #24140e;
+}
+
+.toolbar {
+    background-color: @theme_bg_color;
+}
+
+.message_bar {
+    background-color: @theme_bg_color;
+}
+
+.message_bar_label {
+    color: @theme_fg_color;
+}

--- a/data/tatap.gresource.xml
+++ b/data/tatap.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/aharotias2/tatap">
+    <file alias="Application.css">Application.css</file>
+  </gresource>
+</gresources>

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ if is_debug
     add_project_arguments(['--define', 'DEBUG'], language: 'vala')
 endif
 
+gnome = import('gnome')
 i18n = import('i18n')
 
 add_project_arguments(
@@ -16,8 +17,16 @@ add_project_arguments(
     language: 'c'
 )
 
+asresources = gnome.compile_resources(
+    'as-resources',
+    join_paths('data', 'tatap.gresource.xml'),
+    source_dir: 'data',
+    c_name: 'as'
+)
+
 executable(
     meson.project_name(),
+    asresources,
     'src/Utils/PixbufUtils.vala',
     'src/Utils/TatapFileType.vala',
     'src/Utils/TatapFileUtils.vala',
@@ -45,3 +54,5 @@ i18n.merge_file(
 )
 
 subdir('po')
+
+meson.add_install_script('meson/post_install.py')

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+schema_dir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
+
+if not os.environ.get('DESTDIR'):
+    print('Compiling gsettings schemas…')
+    subprocess.call(['glib-compile-schemas', schema_dir])

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -25,24 +25,6 @@ using Gtk, Gdk;
 public class TatapWindow : Gtk.Window {
     const IconSize ICON_SIZE = IconSize.SMALL_TOOLBAR;
 
-    const string stylesheet = """
-    .image-view {
-        background-color: #24140e;
-    }
-
-    .toolbar {
-        background-color: @theme_bg_color;
-    }
-
-    .message_bar {
-        background-color: @theme_bg_color;
-    }
-
-    .message_bar_label {
-        color: @theme_fg_color;
-    }
-    """;
-
     private const string title_format = "%s (%dx%d : %.2f%%)";
     
     private HeaderBar headerbar;
@@ -407,14 +389,11 @@ public class TatapWindow : Gtk.Window {
     }
 
     private void setup_css() {
-        Screen win_screen = get_screen();
-        CssProvider css_provider = new CssProvider();
-        try {
-            css_provider.load_from_data(stylesheet);
-            Gtk.StyleContext.add_provider_for_screen(win_screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
-        } catch (Error e) {
-            stderr.printf("CssProvider loading failed!\n");
-        }
+        var css_provider = new CssProvider();
+        css_provider.load_from_resource ("/com/github/aharotias2/tatap/Application.css");
+        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (),
+                                                    css_provider,
+                                                    Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
     
     public void open_file(string filename) {


### PR DESCRIPTION
This allows us to use `get_style_context().add_class("class-name")` not only in the TatapWindow.vala but also anywhere of the project. #6 requires this
