### PR TITLE
Redesign header button

### DIFF
--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -29,7 +29,7 @@ public class TatapWindow : Gtk.Window {
 
     private HeaderBar headerbar;
 
-    private NavigationBox navigation_box;
+    private HeaderButtons header_buttons;
 
     private ScrolledWindow image_container;
     public TatapImage image { get; private set; }
@@ -46,7 +46,7 @@ public class TatapWindow : Gtk.Window {
 
     public TatapWindow() {
         /* previous, next, open, and save buttons at the left of the headerbar */
-        navigation_box = new NavigationBox(this);
+        header_buttons = new HeaderButtons(this);
 
         /* menu button at the right of the headerbar */
         var toggle_toolbar_icon = new Image.from_icon_name("view-more-symbolic", ICON_SIZE);
@@ -59,8 +59,7 @@ public class TatapWindow : Gtk.Window {
         });
 
         var header_button_box_right = new ButtonBox(Orientation.HORIZONTAL) {
-            layout_style = ButtonBoxStyle.EXPAND,
-            valign = Gtk.Align.CENTER
+            layout_style = ButtonBoxStyle.EXPAND
         };
         header_button_box_right.add(toolbar_toggle_button);
 
@@ -68,7 +67,7 @@ public class TatapWindow : Gtk.Window {
         headerbar = new HeaderBar() {
             show_close_button = true
         };
-        headerbar.pack_start(navigation_box);
+        headerbar.pack_start(header_buttons);
         headerbar.pack_end(header_button_box_right);
 
         /* image area in the center of the window */
@@ -121,11 +120,11 @@ public class TatapWindow : Gtk.Window {
         Idle.add(() => {
             if (file_list != null) {
                 if (file_list.size == 0) {
-                    navigation_box.set_image_prev_button_sensitivity(false);
-                    navigation_box.set_image_next_button_sensitivity(false);
+                    header_buttons.set_image_prev_button_sensitivity(false);
+                    header_buttons.set_image_next_button_sensitivity(false);
                 } else {
-                    navigation_box.set_image_prev_button_sensitivity(!file_list.file_is_first(true));
-                    navigation_box.set_image_next_button_sensitivity(!file_list.file_is_last(true));
+                    header_buttons.set_image_prev_button_sensitivity(!file_list.file_is_first(true));
+                    header_buttons.set_image_next_button_sensitivity(!file_list.file_is_last(true));
                 }
             }
 
@@ -233,8 +232,8 @@ public class TatapWindow : Gtk.Window {
                 file_list.make_list(image.fileref.get_parent().get_path());
             }
             file_list.set_current(image.fileref);
-            navigation_box.set_image_prev_button_sensitivity(!file_list.file_is_first(true));
-            navigation_box.set_image_next_button_sensitivity(!file_list.file_is_last(true));
+            header_buttons.set_image_prev_button_sensitivity(!file_list.file_is_first(true));
+            header_buttons.set_image_next_button_sensitivity(!file_list.file_is_last(true));
             set_title_label();
         } catch (FileError e) {
             stderr.printf("Error: %s\n", e.message);

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -45,7 +45,7 @@ public class TatapWindow : Gtk.Window {
     private double y;
 
     public TatapWindow() {
-        /* previous/next buttons at the left of the headerbar */
+        /* previous, next, open, and save buttons at the left of the headerbar */
         navigation_box = new NavigationBox(this);
 
         /* menu button at the right of the headerbar */
@@ -59,7 +59,8 @@ public class TatapWindow : Gtk.Window {
         });
 
         var header_button_box_right = new ButtonBox(Orientation.HORIZONTAL) {
-            layout_style = ButtonBoxStyle.EXPAND
+            layout_style = ButtonBoxStyle.EXPAND,
+            valign = Gtk.Align.CENTER
         };
         header_button_box_right.add(toolbar_toggle_button);
 

--- a/src/Widgets/NavigationBox.vala
+++ b/src/Widgets/NavigationBox.vala
@@ -16,7 +16,7 @@
  *  Tanaka Takayuki <msg@gorigorilinux.net>
  */
 
-public class NavigationBox : Gtk.ButtonBox {
+public class NavigationBox : Gtk.Box {
     public TatapWindow window { get; construct; }
 
     private Gtk.Button image_prev_button;
@@ -26,12 +26,12 @@ public class NavigationBox : Gtk.ButtonBox {
         Object (
             window: window,
             orientation: Gtk.Orientation.HORIZONTAL,
-            layout_style: Gtk.ButtonBoxStyle.EXPAND,
             valign: Gtk.Align.CENTER
         );
     }
 
     construct {
+        /* navigation buttons */
         image_prev_button = new ToolButton("go-previous-symbolic", _("Previous"));
         image_prev_button.get_style_context().add_class("image_button");
         image_prev_button.clicked.connect(() => {
@@ -57,8 +57,57 @@ public class NavigationBox : Gtk.ButtonBox {
             }
         });
 
-        add(image_prev_button);
-        add(image_next_button);
+        var file_navigation_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
+            margin = 5,
+            layout_style = Gtk.ButtonBoxStyle.EXPAND
+        };
+        file_navigation_button_box.add(image_prev_button);
+        file_navigation_button_box.add(image_next_button);
+
+        /* action buttons */
+        var open_button = new ToolButton("document-open-symbolic", _("Open"));
+        open_button.clicked.connect(() => {
+            on_open_button_clicked();
+        });
+
+        var save_button = new ToolButton("document-save-symbolic", _("Save as…"));
+        save_button.clicked.connect(() => {
+            on_save_button_clicked();
+        });
+
+        var file_action_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
+            margin = 5,
+            layout_style = Gtk.ButtonBoxStyle.EXPAND
+        };
+        file_action_button_box.add(open_button);
+        file_action_button_box.add(save_button);
+
+        add(file_navigation_button_box);
+        add(file_action_button_box);
+    }
+
+    private void on_open_button_clicked() {
+        var dialog = new Gtk.FileChooserDialog(_("Choose file to open"), window, Gtk.FileChooserAction.OPEN,
+                                           _("Cancel"), Gtk.ResponseType.CANCEL,
+                                           _("Open"), Gtk.ResponseType.ACCEPT);
+        int res = dialog.run();
+        if (res == Gtk.ResponseType.ACCEPT) {
+            string filename = dialog.get_filename();
+            window.open_file(filename);
+        }
+        dialog.close();
+    }
+
+    private void on_save_button_clicked() {
+        var dialog = new Gtk.FileChooserDialog(_("Save as…"), window, Gtk.FileChooserAction.SAVE,
+                                           _("Cancel"), Gtk.ResponseType.CANCEL,
+                                           _("Open"), Gtk.ResponseType.ACCEPT);
+        int res = dialog.run();
+        if (res == Gtk.ResponseType.ACCEPT) {
+            string filename = dialog.get_filename();
+            window.save_file(filename);
+        }
+        dialog.close();
     }
 
     public void set_image_prev_button_sensitivity(bool is_sensitive) {

--- a/src/Widgets/NavigationBox.vala
+++ b/src/Widgets/NavigationBox.vala
@@ -16,24 +16,26 @@
  *  Tanaka Takayuki <msg@gorigorilinux.net>
  */
 
-public class NavigationBox : Gtk.Box {
+public class HeaderButtons : Gtk.Box {
     public TatapWindow window { get; construct; }
 
-    private Gtk.Button image_prev_button;
-    private Gtk.Button image_next_button;
+    private Gtk.ToolButton image_prev_button;
+    private Gtk.ToolButton image_next_button;
 
-    public NavigationBox (TatapWindow window) {
+    public HeaderButtons (TatapWindow window) {
         Object (
             window: window,
             orientation: Gtk.Orientation.HORIZONTAL,
-            valign: Gtk.Align.CENTER
+            spacing: 12
         );
     }
 
     construct {
         /* navigation buttons */
-        image_prev_button = new ToolButton("go-previous-symbolic", _("Previous"));
-        image_prev_button.get_style_context().add_class("image_button");
+        var image_prev_icon = new Gtk.Image.from_icon_name("go-previous", Gtk.IconSize.SMALL_TOOLBAR);
+        image_prev_button = new Gtk.ToolButton(image_prev_icon, null) {
+            tooltip_text = _("Previous")
+        };
         image_prev_button.clicked.connect(() => {
             if (window.file_list != null) {
                 File? prev_file = window.file_list.get_prev_file(window.image.fileref);
@@ -44,8 +46,10 @@ public class NavigationBox : Gtk.Box {
             }
         });
 
-        image_next_button = new ToolButton("go-next-symbolic", _("Next"));
-        image_next_button.get_style_context().add_class("image_button");
+        var image_next_icon = new Gtk.Image.from_icon_name("go-next", Gtk.IconSize.SMALL_TOOLBAR);
+        image_next_button = new Gtk.ToolButton(image_next_icon, null) {
+            tooltip_text = _("Next")
+        };
         image_next_button.clicked.connect(() => {
             if (window.file_list != null) {
                 File? next_file = window.file_list.get_next_file(window.image.fileref);
@@ -57,33 +61,33 @@ public class NavigationBox : Gtk.Box {
             }
         });
 
-        var file_navigation_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
-            margin = 5,
-            layout_style = Gtk.ButtonBoxStyle.EXPAND
-        };
-        file_navigation_button_box.add(image_prev_button);
-        file_navigation_button_box.add(image_next_button);
+        var navigation_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+        navigation_box.pack_start(image_prev_button);
+        navigation_box.pack_start(image_next_button);
 
         /* action buttons */
-        var open_button = new ToolButton("document-open-symbolic", _("Open"));
+        var open_button_icon = new Gtk.Image.from_icon_name("document-open", Gtk.IconSize.SMALL_TOOLBAR);
+        var open_button = new Gtk.ToolButton(open_button_icon, null) {
+            tooltip_text = _("Open")
+        };
         open_button.clicked.connect(() => {
             on_open_button_clicked();
         });
 
-        var save_button = new ToolButton("document-save-symbolic", _("Save as…"));
+        var save_button_icon = new Gtk.Image.from_icon_name("document-save-as", Gtk.IconSize.SMALL_TOOLBAR);
+        var save_button = new Gtk.ToolButton(save_button_icon, null) {
+            tooltip_text = _("Save as…")
+        };
         save_button.clicked.connect(() => {
             on_save_button_clicked();
         });
 
-        var file_action_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
-            margin = 5,
-            layout_style = Gtk.ButtonBoxStyle.EXPAND
-        };
-        file_action_button_box.add(open_button);
-        file_action_button_box.add(save_button);
+        var actions_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+        actions_box.pack_start(open_button);
+        actions_box.pack_start(save_button);
 
-        add(file_navigation_button_box);
-        add(file_action_button_box);
+        add(navigation_box);
+        add(actions_box);
     }
 
     private void on_open_button_clicked() {

--- a/src/Widgets/ToolBarRevealer.vala
+++ b/src/Widgets/ToolBarRevealer.vala
@@ -29,24 +29,6 @@ public class ToolBarRevealer : Gtk.Revealer {
     }
 
     construct {
-        /* action buttons for file */
-        var open_button = new ToolButton("document-open-symbolic", _("Open"));
-        open_button.clicked.connect(() => {
-            on_open_button_clicked();
-        });
-
-        var save_button = new ToolButton("document-save-symbolic", _("Save as…"));
-        save_button.clicked.connect(() => {
-            on_save_button_clicked();
-        });
-
-        var file_action_button_box = new Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL) {
-            margin = 5,
-            layout_style = Gtk.ButtonBoxStyle.EXPAND
-        };
-        file_action_button_box.add(open_button);
-        file_action_button_box.add(save_button);
-
         /* action buttons for the image */
         var zoom_in_button = new ToolButton("zoom-in-symbolic", _("Zoom in"));
         zoom_in_button.get_style_context().add_class("image_overlay_button");
@@ -125,34 +107,9 @@ public class ToolBarRevealer : Gtk.Revealer {
             vexpand = false,
             valign = Gtk.Align.START
         };
-        toolbar_hbox.pack_start(file_action_button_box, false, false);
-        toolbar_hbox.pack_start(image_actions_button_box, false, false);
+        toolbar_hbox.add(image_actions_button_box);
         toolbar_hbox.get_style_context().add_class("toolbar");
 
         add(toolbar_hbox);
-    }
-
-    private void on_open_button_clicked() {
-        var dialog = new Gtk.FileChooserDialog(_("Choose file to open"), window, Gtk.FileChooserAction.OPEN,
-                                           _("Cancel"), Gtk.ResponseType.CANCEL,
-                                           _("Open"), Gtk.ResponseType.ACCEPT);
-        int res = dialog.run();
-        if (res == Gtk.ResponseType.ACCEPT) {
-            string filename = dialog.get_filename();
-            window.open_file(filename);
-        }
-        dialog.close();
-    }
-
-    private void on_save_button_clicked() {
-        var dialog = new Gtk.FileChooserDialog(_("Save as…"), window, Gtk.FileChooserAction.SAVE,
-                                           _("Cancel"), Gtk.ResponseType.CANCEL,
-                                           _("Open"), Gtk.ResponseType.ACCEPT);
-        int res = dialog.run();
-        if (res == Gtk.ResponseType.ACCEPT) {
-            string filename = dialog.get_filename();
-            window.save_file(filename);
-        }
-        dialog.close();
     }
 }


### PR DESCRIPTION
## Before
![Screenshot from 2020-12-29 14-52-04](https://user-images.githubusercontent.com/26003928/103261628-80130280-49e5-11eb-876f-542f1cfa2578.png)

## After
![Screenshot from 2020-12-29 14-46-24](https://user-images.githubusercontent.com/26003928/103261581-5d80e980-49e5-11eb-958b-fa078a8eb418.png)

- Move open and save buttons into the headerbar (fixes #5)
- Switch symbolic icons to vector icons in the headerbar
