### PR TITLE
Add welcome view and switch with stack

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ executable(
     'src/TatapWindow.vala',
     dependencies: [
         dependency('gee-0.8'),
+        dependency('granite'),
         dependency('gtk+-3.0'),
         dependency('gdk-3.0')
     ],

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -94,8 +94,9 @@ public class TatapWindow : Gtk.Window {
         });
 
         /* switch welcome screen and image view */
-        var stack = new Stack();
-        stack.transition_type = StackTransitionType.SLIDE_LEFT_RIGHT;
+        var stack = new Stack() {
+            transition_type = StackTransitionType.SLIDE_LEFT_RIGHT
+        };
         stack.add(welcome);
         stack.add(image_container);
 

--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -70,6 +70,18 @@ public class TatapWindow : Gtk.Window {
         headerbar.pack_start(header_buttons);
         headerbar.pack_end(header_button_box_right);
 
+        /* welcome screen */
+        var welcome = new Granite.Widgets.Welcome(
+            _("No Images Open"),
+            _("Click 'Open Image' to get started.")
+        );
+        welcome.append("document-open", _("Open Image"), _("Show and edit your image."));
+        welcome.activated.connect((i) => {
+            if (i == 0) {
+                on_open_button_clicked();
+            }
+        });
+
         /* image area in the center of the window */
         image = new TatapImage(true);
         image.get_style_context().add_class("image-view");
@@ -80,6 +92,12 @@ public class TatapWindow : Gtk.Window {
             print("Scroll Event\n");
             return false;
         });
+
+        /* switch welcome screen and image view */
+        var stack = new Stack();
+        stack.transition_type = StackTransitionType.SLIDE_LEFT_RIGHT;
+        stack.add(welcome);
+        stack.add(image_container);
 
         /* contain buttons that can be opened from the menu */
         toolbar_revealer = new ToolBarRevealer(this);
@@ -111,7 +129,7 @@ public class TatapWindow : Gtk.Window {
 
         /* Add images and revealer into overlay */
         var window_overlay = new Overlay();
-        window_overlay.add(image_container);
+        window_overlay.add(stack);
         window_overlay.add_overlay(revealer_box);
         window_overlay.set_overlay_pass_through(revealer_box, true);
 
@@ -120,12 +138,16 @@ public class TatapWindow : Gtk.Window {
         Idle.add(() => {
             if (file_list != null) {
                 if (file_list.size == 0) {
+                    stack.visible_child = welcome;
                     header_buttons.set_image_prev_button_sensitivity(false);
                     header_buttons.set_image_next_button_sensitivity(false);
                 } else {
+                    stack.visible_child = image_container;
                     header_buttons.set_image_prev_button_sensitivity(!file_list.file_is_first(true));
                     header_buttons.set_image_next_button_sensitivity(!file_list.file_is_last(true));
                 }
+            } else {
+                stack.visible_child = welcome;
             }
 
             return Source.CONTINUE;
@@ -214,6 +236,18 @@ public class TatapWindow : Gtk.Window {
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (),
                                                     css_provider,
                                                     Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+    }
+
+    public void on_open_button_clicked() {
+        var dialog = new Gtk.FileChooserDialog(_("Choose file to open"), this, Gtk.FileChooserAction.OPEN,
+                                           _("Cancel"), Gtk.ResponseType.CANCEL,
+                                           _("Open"), Gtk.ResponseType.ACCEPT);
+        int res = dialog.run();
+        if (res == Gtk.ResponseType.ACCEPT) {
+            string filename = dialog.get_filename();
+            open_file(filename);
+        }
+        dialog.close();
     }
 
     public void open_file(string filename) {

--- a/src/Widgets/NavigationBox.vala
+++ b/src/Widgets/NavigationBox.vala
@@ -49,7 +49,7 @@ public class HeaderButtons : Gtk.Box {
             tooltip_text = _("Open")
         };
         open_button.clicked.connect(() => {
-            on_open_button_clicked();
+            window.on_open_button_clicked();
         });
 
         var save_button_icon = new Gtk.Image.from_icon_name("document-save-as", Gtk.IconSize.SMALL_TOOLBAR);
@@ -66,18 +66,6 @@ public class HeaderButtons : Gtk.Box {
 
         add(navigation_box);
         add(actions_box);
-    }
-
-    private void on_open_button_clicked() {
-        var dialog = new Gtk.FileChooserDialog(_("Choose file to open"), window, Gtk.FileChooserAction.OPEN,
-                                           _("Cancel"), Gtk.ResponseType.CANCEL,
-                                           _("Open"), Gtk.ResponseType.ACCEPT);
-        int res = dialog.run();
-        if (res == Gtk.ResponseType.ACCEPT) {
-            string filename = dialog.get_filename();
-            window.open_file(filename);
-        }
-        dialog.close();
     }
 
     private void on_save_button_clicked() {


### PR DESCRIPTION
## Before
![Screenshot from 2020-12-31 11-43-44](https://user-images.githubusercontent.com/26003928/103391566-744a4c00-4b5d-11eb-9db9-e65b3ecc621a.png)

Users would be a little confused what they need to do first because the main content is blank and have to click the small open icon in the headerbar to get started

## After
![2020-12-31 11 41 01 の画面録画](https://user-images.githubusercontent.com/26003928/103391528-4bc25200-4b5d-11eb-8d3e-07a31decb2ba.gif)

I added a welcome screen using granite. This should allow users knowing what to do easily.

However, unfortunately this has a regression; the image is not displayed by default for some reason. Shaking the window or zooming in displays the image correctly but apparently this is a side effect of this branch. I assume this is because the app cannot decide the image size correctly but @aharotias2 what do you think happens here? I guess you're familiar with gdk/pixbuf related things :bowing_woman:
