### PR TITLE
Remove extra comma

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,9 +7,8 @@ Build-Depends: debhelper (>= 10.5.1),
                libgee-0.8-dev
                libgranite-dev,
                libgtk3-dev,
-               ninja (>= 1.0),
                meson (>= 0.5),
-               valac (>= 0.40.0),
+               valac (>= 0.40.0)
 Standards-Version: 4.1.1
 
 Package: com.github.aharotias2.tatap


### PR DESCRIPTION
Fixes [gettext action is failing](https://github.com/aharotias2/tatap/runs/1675658010?check_suite_focus=true) with the following message:

```
E: Problem parsing dependency: Build-Depends
E: Unable to get build-dependency information for .
```

Also remove `ninja` (actually we should have to say `ninja-build` though) because meson depends on it
