### PR TITLE
Remove extra debug message

### DIFF
--- a/src/TatapWindow.vala
+++ b/src/TatapWindow.vala
@@ -378,7 +378,6 @@ public class TatapWindow : Gtk.Window {
     public void go_next() {
         if (file_list != null) {
             File? next_file = file_list.get_next_file(image.fileref);
-            debug("next file: %s", next_file.get_basename());
 
             if (next_file != null) {
                 open_file(next_file.get_path());


### PR DESCRIPTION
You get the following error message when you press the right arrow key if there are no next image:

```
(com.github.aharotias2.tatap:6178): GLib-GIO-CRITICAL **: 09:49:16.825: g_file_get_basename: assertion 'G_IS_FILE (file)' failed
```

Investigating with gdb the following line causes this error if the `next_file` is null. So simply we can fix this issue by moving that line into the next `if` sentence. However I feel we might want to remove it because

- this debug info has less meaning
- the counterpart method `go_prev` does not have this debug message
