### PR TITLE
Add Flatpak manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.flatpak-builder
 build
+build-dir

--- a/com.github.aharotias2.parapara.yml
+++ b/com.github.aharotias2.parapara.yml
@@ -1,0 +1,17 @@
+app-id: com.github.aharotias2.parapara
+runtime: io.elementary.Platform
+runtime-version: 'daily'
+sdk: io.elementary.Sdk
+command: com.github.aharotias2.parapara
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --filesystem=home
+  # needed for perfers-color-scheme
+  - --system-talk-name=org.freedesktop.Accounts
+modules:
+  - name: parapara
+    buildsystem: meson
+    sources:
+      - type: dir
+        path: .

--- a/com.github.aharotias2.parapara.yml
+++ b/com.github.aharotias2.parapara.yml
@@ -4,11 +4,12 @@ runtime-version: 'daily'
 sdk: io.elementary.Sdk
 command: com.github.aharotias2.parapara
 finish-args:
-  - --socket=wayland
-  - --socket=fallback-x11
-  - --filesystem=home
+  - '--share=ipc'
+  - '--socket=wayland'
+  - '--socket=fallback-x11'
+  - '--filesystem=home'
   # needed for perfers-color-scheme
-  - --system-talk-name=org.freedesktop.Accounts
+  - '--system-talk-name=org.freedesktop.Accounts'
 modules:
   - name: parapara
     buildsystem: meson


### PR DESCRIPTION
AppCenter on elementary OS is moving to its packaging system from Debian Packaging to Flatpak when the next major version, 6.0 Odin, is released.

@aharotias2 Would you delete the `deb-packaging` branch after merging this PR since it's no longer needed for us?
