### PR TITLE
Use GNOME's SDK instead of elementary one

### DIFF
--- a/com.github.aharotias2.parapara.yml
+++ b/com.github.aharotias2.parapara.yml
@@ -1,16 +1,21 @@
 app-id: com.github.aharotias2.parapara
-runtime: io.elementary.Platform
-runtime-version: '6'
-sdk: io.elementary.Sdk
+runtime: org.gnome.Platform
+runtime-version: '41'
+sdk: org.gnome.Sdk
 command: com.github.aharotias2.parapara
 finish-args:
   - '--share=ipc'
   - '--socket=wayland'
   - '--socket=fallback-x11'
   - '--filesystem=home'
-  # needed for perfers-color-scheme
-  - '--system-talk-name=org.freedesktop.Accounts'
 modules:
+  - name: granite
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/elementary/granite.git
+        tag: '6.2.0'
+        commit: 4ab145c28bb3db6372fe519e8bd79c645edfcda3
   - name: parapara
     buildsystem: meson
     sources:


### PR DESCRIPTION
According to [your comment](https://github.com/aharotias2/parapara/issues/2#issuecomment-910406880) you're using XFce on Arch Linux, not elementary OS, so replacing elementary SDK with GNOME one because elementary SDK is only available from [its Flatpak repository](https://flatpak.elementary.io) that is not available on other distributions by default.

Since we're using granite included in elementary SDK, we now need to explicit it as a module.
