### PR TITLE
Window: Make some strings translatable

### DIFF
--- a/po/com.github.aharotias2.parapara.pot
+++ b/po/com.github.aharotias2.parapara.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.aharotias2.parapara\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-19 16:53+0900\n"
+"POT-Creation-Date: 2022-03-22 10:14+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,7 +52,7 @@ msgid "OK"
 msgstr ""
 
 #: src/Widgets/ResizeDialog.vala:122 src/Widgets/SingleImageView.vala:531
-#: src/Widgets/Window.vala:613
+#: src/Widgets/Window.vala:620
 msgid "Cancel"
 msgstr ""
 
@@ -220,55 +220,66 @@ msgstr ""
 msgid "Sort:"
 msgstr ""
 
-#: src/Widgets/Window.vala:115 src/Widgets/Window.vala:613 data/gtk/menus.ui:33
+#: src/Widgets/Window.vala:116 src/Widgets/Window.vala:620 data/gtk/menus.ui:33
 msgid "Open"
 msgstr ""
 
-#: src/Widgets/Window.vala:130
+#: src/Widgets/Window.vala:131
 msgid "Previous"
 msgstr ""
 
-#: src/Widgets/Window.vala:148
+#: src/Widgets/Window.vala:149
 msgid "Next"
 msgstr ""
 
-#: src/Widgets/Window.vala:191
+#: src/Widgets/Window.vala:192
 msgid "No Images Open"
 msgstr ""
 
-#: src/Widgets/Window.vala:191
+#: src/Widgets/Window.vala:192
 msgid "Click 'Open Image' to get started."
 msgstr ""
 
-#: src/Widgets/Window.vala:193
+#: src/Widgets/Window.vala:194
 msgid "Open Image"
 msgstr ""
 
-#: src/Widgets/Window.vala:193
+#: src/Widgets/Window.vala:194
 msgid "Show and edit your image."
 msgstr ""
 
-#: src/Widgets/Window.vala:229 src/Widgets/Window.vala:329
-#: src/Widgets/Window.vala:649 src/Widgets/Window.vala:735
+#: src/Widgets/Window.vala:230 src/Widgets/Window.vala:330
+#: src/Widgets/Window.vala:656 src/Widgets/Window.vala:742
 #, c-format
 msgid "Location: %d / %d (%d%%)"
 msgstr ""
 
-#: src/Widgets/Window.vala:612
+#: src/Widgets/Window.vala:619
 msgid "Choose file to open"
 msgstr ""
 
-#: src/Widgets/Window.vala:639
+#: src/Widgets/Window.vala:646
 msgid "The directory does not found. Exiting."
 msgstr ""
 
-#: src/Widgets/Window.vala:643
+#: src/Widgets/Window.vala:650
 msgid "The file does not found."
 msgstr ""
 
-#: src/Widgets/Window.vala:692
+#: src/Widgets/Window.vala:699
 #, c-format
 msgid "The file could not be opend (cause: %s)"
+msgstr ""
+
+#. TRANSLATORS: Replace with your name and email address, don't translate literally
+#: src/Widgets/Window.vala:780
+msgid "translator-credits"
+msgstr ""
+
+#: src/Widgets/Window.vala:782
+msgid ""
+"A lightweight image viewer with three display modes: single, spread, and "
+"continuous."
 msgstr ""
 
 #: data/gtk/menus.ui:7

--- a/po/extra/extra.pot
+++ b/po/extra/extra.pot
@@ -3,11 +3,12 @@
 # This file is distributed under the same license as the extra package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-13 02:42+0000\n"
+"POT-Creation-Date: 2022-03-22 10:15+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,19 +17,59 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: data/parapara.appdata.xml.in:7 data/parapara.desktop.in:3
+#: data/parapara.appdata.xml.in:8 data/parapara.desktop.in:3
 msgid "ParaPara"
 msgstr ""
 
-#: data/parapara.appdata.xml.in:8
+#: data/parapara.appdata.xml.in:9
 msgid "An image viewer without library"
 msgstr ""
 
-#: data/parapara.appdata.xml.in:10
-msgid "An image viewer that supports jpg, png, bmp, and ico files."
+#: data/parapara.appdata.xml.in:11
+msgid ""
+"An image viewer in which images are displayed as one of three styles: "
+"single, spread (book), continuous (scrolling), and that supports jpg, png, "
+"bmp, ico, gif files. animated gifs are also supported."
 msgstr ""
 
-#: data/parapara.appdata.xml.in:53
+#: data/parapara.appdata.xml.in:20
+msgid "Application Screenshot (Single View Mode)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:24
+msgid "Spread View Mode"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:28
+msgid "Continuous View Mode (Vertical)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:32
+msgid "Continuous View Mode (Horizontal)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:70
+msgid "Update meson.build"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:75
+msgid "Update appdata.xml"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:80
+msgid ""
+"This release further standardizes the user interface. That is, like many "
+"other GNOME applications such as Gedit, we have made it with a menu button "
+"on the top right. When you press this button, you will see a pop-up menu as "
+"most people expect. (Previously, the toolbar was displayed.) There is no "
+"change in the functionality itself."
+msgstr ""
+
+#: data/parapara.appdata.xml.in:91
+msgid "Initial release."
+msgstr ""
+
+#: data/parapara.appdata.xml.in:97
 msgid "Tanaka Takayuki"
 msgstr ""
 
@@ -40,10 +81,6 @@ msgstr ""
 msgid "View image files"
 msgstr ""
 
-#: data/parapara.desktop.in:8
-msgid "image-viewer"
-msgstr ""
-
-#: data/parapara.desktop.in:13
+#: data/parapara.desktop.in:12
 msgid "Picture;Image;Viewer;"
 msgstr ""

--- a/po/extra/it.po
+++ b/po/extra/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-13 02:42+0000\n"
+"POT-Creation-Date: 2022-03-22 10:15+0900\n"
 "PO-Revision-Date: 2021-12-09 20:54+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -16,19 +16,59 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: data/parapara.appdata.xml.in:7 data/parapara.desktop.in:3
+#: data/parapara.appdata.xml.in:8 data/parapara.desktop.in:3
 msgid "ParaPara"
 msgstr "ParaPara"
 
-#: data/parapara.appdata.xml.in:8
+#: data/parapara.appdata.xml.in:9
 msgid "An image viewer without library"
 msgstr "Un visualizzatore di immagini senza libreria"
 
-#: data/parapara.appdata.xml.in:10
-msgid "An image viewer that supports jpg, png, bmp, and ico files."
-msgstr "Un visualizzatore di immagini che supporta file jpg, png, bmp e ico."
+#: data/parapara.appdata.xml.in:11
+msgid ""
+"An image viewer in which images are displayed as one of three styles: "
+"single, spread (book), continuous (scrolling), and that supports jpg, png, "
+"bmp, ico, gif files. animated gifs are also supported."
+msgstr ""
 
-#: data/parapara.appdata.xml.in:53
+#: data/parapara.appdata.xml.in:20
+msgid "Application Screenshot (Single View Mode)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:24
+msgid "Spread View Mode"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:28
+msgid "Continuous View Mode (Vertical)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:32
+msgid "Continuous View Mode (Horizontal)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:70
+msgid "Update meson.build"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:75
+msgid "Update appdata.xml"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:80
+msgid ""
+"This release further standardizes the user interface. That is, like many "
+"other GNOME applications such as Gedit, we have made it with a menu button "
+"on the top right. When you press this button, you will see a pop-up menu as "
+"most people expect. (Previously, the toolbar was displayed.) There is no "
+"change in the functionality itself."
+msgstr ""
+
+#: data/parapara.appdata.xml.in:91
+msgid "Initial release."
+msgstr ""
+
+#: data/parapara.appdata.xml.in:97
 msgid "Tanaka Takayuki"
 msgstr "Tanaka Takayuki"
 
@@ -40,10 +80,13 @@ msgstr "Visualizzatore di immagini"
 msgid "View image files"
 msgstr "Visualizza file immagine"
 
-#: data/parapara.desktop.in:8
-msgid "image-viewer"
-msgstr "visualizzatore-immagini"
-
-#: data/parapara.desktop.in:13
+#: data/parapara.desktop.in:12
 msgid "Picture;Image;Viewer;"
 msgstr "Foto;Immagine;Visualizzatore;"
+
+#~ msgid "An image viewer that supports jpg, png, bmp, and ico files."
+#~ msgstr ""
+#~ "Un visualizzatore di immagini che supporta file jpg, png, bmp e ico."
+
+#~ msgid "image-viewer"
+#~ msgstr "visualizzatore-immagini"

--- a/po/extra/ja.po
+++ b/po/extra/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-13 02:42+0000\n"
+"POT-Creation-Date: 2022-03-22 10:15+0900\n"
 "PO-Revision-Date: 2020-12-23 21:31+0900\n"
 "Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: none\n"
@@ -18,19 +18,59 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: data/parapara.appdata.xml.in:7 data/parapara.desktop.in:3
+#: data/parapara.appdata.xml.in:8 data/parapara.desktop.in:3
 msgid "ParaPara"
 msgstr "ParaPara"
 
-#: data/parapara.appdata.xml.in:8
+#: data/parapara.appdata.xml.in:9
 msgid "An image viewer without library"
 msgstr "ライブラリー機能のない画像ビューアー"
 
-#: data/parapara.appdata.xml.in:10
-msgid "An image viewer that supports jpg, png, bmp, and ico files."
-msgstr "jpg、png、bmp、、ico ファイルに対応する画像ビューアーです。"
+#: data/parapara.appdata.xml.in:11
+msgid ""
+"An image viewer in which images are displayed as one of three styles: "
+"single, spread (book), continuous (scrolling), and that supports jpg, png, "
+"bmp, ico, gif files. animated gifs are also supported."
+msgstr ""
 
-#: data/parapara.appdata.xml.in:53
+#: data/parapara.appdata.xml.in:20
+msgid "Application Screenshot (Single View Mode)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:24
+msgid "Spread View Mode"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:28
+msgid "Continuous View Mode (Vertical)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:32
+msgid "Continuous View Mode (Horizontal)"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:70
+msgid "Update meson.build"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:75
+msgid "Update appdata.xml"
+msgstr ""
+
+#: data/parapara.appdata.xml.in:80
+msgid ""
+"This release further standardizes the user interface. That is, like many "
+"other GNOME applications such as Gedit, we have made it with a menu button "
+"on the top right. When you press this button, you will see a pop-up menu as "
+"most people expect. (Previously, the toolbar was displayed.) There is no "
+"change in the functionality itself."
+msgstr ""
+
+#: data/parapara.appdata.xml.in:91
+msgid "Initial release."
+msgstr ""
+
+#: data/parapara.appdata.xml.in:97
 msgid "Tanaka Takayuki"
 msgstr "Tanaka Takayuki"
 
@@ -42,10 +82,12 @@ msgstr "画像ビューアー"
 msgid "View image files"
 msgstr "画像ファイルを表示します"
 
-#: data/parapara.desktop.in:8
-msgid "image-viewer"
-msgstr "画像ビューアー"
-
-#: data/parapara.desktop.in:13
+#: data/parapara.desktop.in:12
 msgid "Picture;Image;Viewer;"
 msgstr "Picture;Image;Viewer;ピクチャー;画像;イメージ;ビューアー;ビューワー;"
+
+#~ msgid "An image viewer that supports jpg, png, bmp, and ico files."
+#~ msgstr "jpg、png、bmp、、ico ファイルに対応する画像ビューアーです。"
+
+#~ msgid "image-viewer"
+#~ msgstr "画像ビューアー"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-19 16:53+0900\n"
+"POT-Creation-Date: 2022-03-22 10:14+0900\n"
 "PO-Revision-Date: 2022-02-27 14:10+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -51,7 +51,7 @@ msgid "OK"
 msgstr "OK"
 
 #: src/Widgets/ResizeDialog.vala:122 src/Widgets/SingleImageView.vala:531
-#: src/Widgets/Window.vala:613
+#: src/Widgets/Window.vala:620
 msgid "Cancel"
 msgstr "Cancella"
 
@@ -219,56 +219,67 @@ msgstr "Orientamento:"
 msgid "Sort:"
 msgstr "Ordina:"
 
-#: src/Widgets/Window.vala:115 src/Widgets/Window.vala:613 data/gtk/menus.ui:33
+#: src/Widgets/Window.vala:116 src/Widgets/Window.vala:620 data/gtk/menus.ui:33
 msgid "Open"
 msgstr "Apri"
 
-#: src/Widgets/Window.vala:130
+#: src/Widgets/Window.vala:131
 msgid "Previous"
 msgstr "Precedente"
 
-#: src/Widgets/Window.vala:148
+#: src/Widgets/Window.vala:149
 msgid "Next"
 msgstr "Prossimo"
 
-#: src/Widgets/Window.vala:191
+#: src/Widgets/Window.vala:192
 msgid "No Images Open"
 msgstr "Nessuna Immagine Aperta"
 
-#: src/Widgets/Window.vala:191
+#: src/Widgets/Window.vala:192
 msgid "Click 'Open Image' to get started."
 msgstr "Fai clic su 'Apri Immagine' per iniziare."
 
-#: src/Widgets/Window.vala:193
+#: src/Widgets/Window.vala:194
 msgid "Open Image"
 msgstr "Apri Immagine"
 
-#: src/Widgets/Window.vala:193
+#: src/Widgets/Window.vala:194
 msgid "Show and edit your image."
 msgstr "Mostra e modifica la tua immagine."
 
-#: src/Widgets/Window.vala:229 src/Widgets/Window.vala:329
-#: src/Widgets/Window.vala:649 src/Widgets/Window.vala:735
+#: src/Widgets/Window.vala:230 src/Widgets/Window.vala:330
+#: src/Widgets/Window.vala:656 src/Widgets/Window.vala:742
 #, c-format
 msgid "Location: %d / %d (%d%%)"
 msgstr "Posizione: %d / %d (%d%%)"
 
-#: src/Widgets/Window.vala:612
+#: src/Widgets/Window.vala:619
 msgid "Choose file to open"
 msgstr "Scegli un file da aprire"
 
-#: src/Widgets/Window.vala:639
+#: src/Widgets/Window.vala:646
 msgid "The directory does not found. Exiting."
 msgstr "La directory non è stata trovata. Uscire."
 
-#: src/Widgets/Window.vala:643
+#: src/Widgets/Window.vala:650
 msgid "The file does not found."
 msgstr "Il file non è stato trovato."
 
-#: src/Widgets/Window.vala:692
+#: src/Widgets/Window.vala:699
 #, c-format
 msgid "The file could not be opend (cause: %s)"
 msgstr "Impossibile aprire il file (motivo: %s)"
+
+#. TRANSLATORS: Replace with your name and email address, don't translate literally
+#: src/Widgets/Window.vala:780
+msgid "translator-credits"
+msgstr ""
+
+#: src/Widgets/Window.vala:782
+msgid ""
+"A lightweight image viewer with three display modes: single, spread, and "
+"continuous."
+msgstr ""
 
 #: data/gtk/menus.ui:7
 msgid "Single View Mode"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,16 +1,16 @@
 # Japanese translations for com.github.aharotias2.parapara package.
-# Copyright (C) 2020-2021 THE com.github.aharotias2.parapara'S COPYRIGHT HOLDER
+# Copyright (C) 2019-2022 THE com.github.aharotias2.parapara'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.aharotias2.parapara package.
 # Tanaka Takayuki <aharotias2@gmail.com>, 2019-2021.
-# Ryo Nakano <ryonakaknock3@gmail.com>, 2020-2021.
+# Ryo Nakano <ryonakaknock3@gmail.com>, 2020-2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.github.aharotias2.parapara\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-03-22 10:14+0900\n"
-"PO-Revision-Date: 2021-01-14 11:54+0900\n"
-"Last-Translator: Takayuki Tanaka <aharotias2@gmail.com>\n"
+"PO-Revision-Date: 2022-03-22 10:24+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: none\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
@@ -59,7 +59,7 @@ msgstr "キャンセル"
 
 #: src/Widgets/SingleImageView.vala:417
 msgid ":\n"
-msgstr ""
+msgstr ":\n"
 
 #: src/Widgets/SingleImageView.vala:513
 msgid "The image was resized."
@@ -95,7 +95,7 @@ msgstr "ファイルの保存はキャンセルされました。"
 
 #: src/Widgets/SingleImageView.vala:580
 msgid "The file was saved"
-msgstr "ファイルを保存しました。"
+msgstr "ファイルを保存しました"
 
 #: src/Widgets/ToolBar.vala:156
 msgid "Resize"
@@ -175,7 +175,7 @@ msgstr "右から左へ"
 
 #: src/Widgets/ToolBar.vala:486
 msgid "Fit Width"
-msgstr "幅:"
+msgstr "幅に合わせる"
 
 #: src/Widgets/ToolBar.vala:487
 msgid "Fit Page"
@@ -211,7 +211,7 @@ msgstr "左右反転"
 
 #: src/Widgets/ToolBar.vala:608
 msgid "Zoom:"
-msgstr "拡大"
+msgstr "拡大:"
 
 #: src/Widgets/ToolBar.vala:610
 msgid "Orientation:"
@@ -219,7 +219,7 @@ msgstr "縦/横:"
 
 #: src/Widgets/ToolBar.vala:612
 msgid "Sort:"
-msgstr "昇順"
+msgstr "並べ替え:"
 
 #: src/Widgets/Window.vala:116 src/Widgets/Window.vala:620 data/gtk/menus.ui:33
 msgid "Open"
@@ -247,7 +247,7 @@ msgstr "画像を開く"
 
 #: src/Widgets/Window.vala:194
 msgid "Show and edit your image."
-msgstr "画像を閲覧/編集できます"
+msgstr "画像を閲覧/編集できます。"
 
 #: src/Widgets/Window.vala:230 src/Widgets/Window.vala:330
 #: src/Widgets/Window.vala:656 src/Widgets/Window.vala:742
@@ -276,6 +276,8 @@ msgstr "ファイルを開けません (理由: %s)"
 #: src/Widgets/Window.vala:780
 msgid "translator-credits"
 msgstr ""
+"Tanaka Takayuki <aharotias2@gmail.com>\n"
+"Ryo Nakano <ryonakaknock3@gmail.com>"
 
 #: src/Widgets/Window.vala:782
 msgid ""
@@ -321,4 +323,4 @@ msgstr "フルスクリーン"
 
 #: data/gtk/menus.ui:75
 msgid "About…"
-msgstr "このアプリについて…"
+msgstr "ParaPara について…"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.aharotias2.parapara\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-19 16:53+0900\n"
+"POT-Creation-Date: 2022-03-22 10:14+0900\n"
 "PO-Revision-Date: 2021-01-14 11:54+0900\n"
 "Last-Translator: Takayuki Tanaka <aharotias2@gmail.com>\n"
 "Language-Team: none\n"
@@ -53,7 +53,7 @@ msgid "OK"
 msgstr "OK"
 
 #: src/Widgets/ResizeDialog.vala:122 src/Widgets/SingleImageView.vala:531
-#: src/Widgets/Window.vala:613
+#: src/Widgets/Window.vala:620
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -221,56 +221,67 @@ msgstr "縦/横:"
 msgid "Sort:"
 msgstr "昇順"
 
-#: src/Widgets/Window.vala:115 src/Widgets/Window.vala:613 data/gtk/menus.ui:33
+#: src/Widgets/Window.vala:116 src/Widgets/Window.vala:620 data/gtk/menus.ui:33
 msgid "Open"
 msgstr "開く"
 
-#: src/Widgets/Window.vala:130
+#: src/Widgets/Window.vala:131
 msgid "Previous"
 msgstr "前の画像"
 
-#: src/Widgets/Window.vala:148
+#: src/Widgets/Window.vala:149
 msgid "Next"
 msgstr "次の画像"
 
-#: src/Widgets/Window.vala:191
+#: src/Widgets/Window.vala:192
 msgid "No Images Open"
 msgstr "画像が開いていません"
 
-#: src/Widgets/Window.vala:191
+#: src/Widgets/Window.vala:192
 msgid "Click 'Open Image' to get started."
 msgstr "「画像を開く」をクリックして開始しましょう。"
 
-#: src/Widgets/Window.vala:193
+#: src/Widgets/Window.vala:194
 msgid "Open Image"
 msgstr "画像を開く"
 
-#: src/Widgets/Window.vala:193
+#: src/Widgets/Window.vala:194
 msgid "Show and edit your image."
 msgstr "画像を閲覧/編集できます"
 
-#: src/Widgets/Window.vala:229 src/Widgets/Window.vala:329
-#: src/Widgets/Window.vala:649 src/Widgets/Window.vala:735
+#: src/Widgets/Window.vala:230 src/Widgets/Window.vala:330
+#: src/Widgets/Window.vala:656 src/Widgets/Window.vala:742
 #, c-format
 msgid "Location: %d / %d (%d%%)"
 msgstr "ロケーション: %d / %d (%d%%)"
 
-#: src/Widgets/Window.vala:612
+#: src/Widgets/Window.vala:619
 msgid "Choose file to open"
 msgstr "開くファイルを選択"
 
-#: src/Widgets/Window.vala:639
+#: src/Widgets/Window.vala:646
 msgid "The directory does not found. Exiting."
 msgstr "ディレクトリが存在しません。終了します。"
 
-#: src/Widgets/Window.vala:643
+#: src/Widgets/Window.vala:650
 msgid "The file does not found."
 msgstr "ファイルが見つかりません。"
 
-#: src/Widgets/Window.vala:692
+#: src/Widgets/Window.vala:699
 #, c-format
 msgid "The file could not be opend (cause: %s)"
 msgstr "ファイルを開けません (理由: %s)"
+
+#. TRANSLATORS: Replace with your name and email address, don't translate literally
+#: src/Widgets/Window.vala:780
+msgid "translator-credits"
+msgstr ""
+
+#: src/Widgets/Window.vala:782
+msgid ""
+"A lightweight image viewer with three display modes: single, spread, and "
+"continuous."
+msgstr ""
 
 #: data/gtk/menus.ui:7
 msgid "Single View Mode"

--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -776,9 +776,10 @@ namespace ParaPara {
             dialog.artists = {"Nararyans R.I. @Fatih20"};
             dialog.authors = {"Takayuki Tanaka @aharotias2", "Ryo Nakano @ryonakano"};
             dialog.documenters = null;
-            dialog.translator_credits = null;
+            //TRANSLATORS: Replace with your name and email address, don't translate literally
+            dialog.translator_credits = _("translator-credits");
             dialog.program_name = "ParaPara";
-            dialog.comments = "A lightweight image viewer with three display modes: single, spread, and continuous.";
+            dialog.comments = _("A lightweight image viewer with three display modes: single, spread, and continuous.");
             dialog.copyright = "Copyright (C) 2020-2022 Takayuki Tanaka";
             dialog.version = VERSION;
             dialog.license =


### PR DESCRIPTION
It's common in GNOME apps to make the translators credits and app description in the AboutDialog translatable (like [this](https://github.com/GNOME/dconf-editor/blob/41691c16e096a34583c3946195f38f8a6e131878/po/ja.po#L1175-L1182)), so we should follow that:

![Screenshot from 2022-03-22 10-32-45](https://user-images.githubusercontent.com/26003928/159389651-505c163b-8b57-4ca8-94e1-829d77c701bc.png)

Also, the Japanese translation against the phrase "About…" commonly used  is "(app name) について…" instead of "このアプリについて…", so I fixed that too.
Finally I updated the all translation files to reflect these changes.
