### PR TITLE
Appdata related changes

### DIFF
--- a/data/parapara.appdata.xml.in
+++ b/data/parapara.appdata.xml.in
@@ -39,27 +39,27 @@
 
   <releases>
     <release version="3.2.9" date="2022-03-26" urgency="medium">
-      <description translatable="no">
+      <description translate="no">
 	<p>Update it.po</p>
       </description>
     </release>
     <release version="3.2.8" date="2022-03-25" urgency="medium">
-      <description translatable="no">
+      <description translate="no">
 	<p>Update translation</p>
       </description>
     </release>
     <release version="3.2.3" date="2022-01-10" urgency="medium">
-      <description translatable="no">
+      <description translate="no">
 	<p>Update meson.build</p>
       </description>
     </release>
     <release version="3.2.2" date="2022-01-09" urgency="medium">
-      <description translatable="no">
+      <description translate="no">
 	<p>Update appdata.xml</p>
       </description>
     </release>
     <release version="3.2.0" date="2021-12-24" urgency="medium">
-      <description translatable="no">
+      <description translate="no">
         <p>This release further standardizes the user interface.
 	  That is, like many other GNOME applications such as Gedit,
 	  we have made it with a menu button on the top right.
@@ -69,7 +69,7 @@
       </description>
     </release>
     <release version="3.0.0" date="2021-08-07" urgency="medium">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Initial release.</li>
         </ul>

--- a/data/parapara.appdata.xml.in
+++ b/data/parapara.appdata.xml.in
@@ -78,6 +78,9 @@
   </releases>
 
   <developer_name>Tanaka Takayuki</developer_name>
+  <developer id="io.github.aharotias2">
+    <name>Tanaka Takayuki</name>
+  </developer>
   <url type="homepage">https://github.com/aharotias2/parapara</url>
   <url type="bugtracker">https://github.com/aharotias2/parapara/issues</url>
   <url type="help">https://github.com/aharotias2/parapara/issues</url>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer